### PR TITLE
Add KPI field sub-fields for structured multi-line items

### DIFF
--- a/backend/alembic/versions/006_kpi_field_sub_fields.py
+++ b/backend/alembic/versions/006_kpi_field_sub_fields.py
@@ -1,0 +1,42 @@
+"""Add kpi_field_sub_fields for structured multi_line_items.
+
+Revision ID: 006_sub_fields
+Revises: 005_card_display
+Create Date: 2025-02-04
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "006_sub_fields"
+down_revision: Union[str, None] = "005_card_display"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create table without field_type first to avoid SQLAlchemy trying to create the enum type.
+    # The "fieldtype" enum already exists from 001_initial_schema.
+    op.create_table(
+        "kpi_field_sub_fields",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("field_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("key", sa.String(100), nullable=False),
+        sa.Column("is_required", sa.Boolean(), nullable=True, server_default="false"),
+        sa.Column("sort_order", sa.Integer(), nullable=True, server_default="0"),
+        sa.ForeignKeyConstraint(["field_id"], ["kpi_fields.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Add column using existing PostgreSQL enum type (no CREATE TYPE).
+    op.execute("ALTER TABLE kpi_field_sub_fields ADD COLUMN field_type fieldtype NOT NULL DEFAULT 'single_line_text'")
+    op.execute("ALTER TABLE kpi_field_sub_fields ALTER COLUMN field_type DROP DEFAULT")
+    op.create_index("ix_kpi_field_sub_fields_field_id", "kpi_field_sub_fields", ["field_id"], unique=False)
+    op.create_index("ix_kpi_field_sub_fields_key", "kpi_field_sub_fields", ["key"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kpi_field_sub_fields_key", table_name="kpi_field_sub_fields")
+    op.drop_index("ix_kpi_field_sub_fields_field_id", table_name="kpi_field_sub_fields")
+    op.drop_table("kpi_field_sub_fields")

--- a/backend/app/core/models.py
+++ b/backend/app/core/models.py
@@ -259,6 +259,9 @@ class KPIField(Base):
 
     kpi = relationship("KPI", back_populates="fields")
     options = relationship("KPIFieldOption", back_populates="field", lazy="selectin")
+    sub_fields = relationship(
+        "KPIFieldSubField", back_populates="field", lazy="selectin", order_by="KPIFieldSubField.sort_order"
+    )
     values = relationship("KPIFieldValue", back_populates="field", lazy="selectin")
     report_template_fields = relationship(
         "ReportTemplateField", back_populates="kpi_field", lazy="selectin"
@@ -279,6 +282,24 @@ class KPIFieldOption(Base):
     sort_order = Column(Integer, default=0)
 
     field = relationship("KPIField", back_populates="options")
+
+
+class KPIFieldSubField(Base):
+    """Sub-field definition for multi_line_items KPI field (structured columns per row)."""
+
+    __tablename__ = "kpi_field_sub_fields"
+
+    id = Column(Integer, primary_key=True, index=True)
+    field_id = Column(
+        Integer, ForeignKey("kpi_fields.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name = Column(String(255), nullable=False)
+    key = Column(String(100), nullable=False, index=True)
+    field_type = Column(Enum(FieldType), nullable=False)  # single_line_text, number, date, boolean only
+    is_required = Column(Boolean, default=False)
+    sort_order = Column(Integer, default=0)
+
+    field = relationship("KPIField", back_populates="sub_fields")
 
 
 class KPIAssignment(Base):

--- a/backend/app/entries/routes.py
+++ b/backend/app/entries/routes.py
@@ -103,6 +103,10 @@ async def get_entry_fields(
             "is_required": f.is_required,
             "sort_order": f.sort_order,
             "options": [{"value": o.value, "label": o.label} for o in (f.options or [])],
+            "sub_fields": [
+                {"id": s.id, "field_id": s.field_id, "name": s.name, "key": s.key, "field_type": s.field_type.value, "is_required": s.is_required, "sort_order": s.sort_order}
+                for s in (getattr(f, "sub_fields", None) or [])
+            ],
         }
         for f in fields
     ]

--- a/backend/app/fields/schemas.py
+++ b/backend/app/fields/schemas.py
@@ -6,6 +6,35 @@ from typing import Any
 from app.core.models import FieldType
 
 
+# Allowed sub-field types for multi_line_items (one column type per sub-field)
+SUB_FIELD_TYPES = (FieldType.single_line_text, FieldType.number, FieldType.date, FieldType.boolean)
+
+
+class KPIFieldSubFieldCreate(BaseModel):
+    """Sub-field for multi_line_items (column definition)."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    key: str = Field(..., min_length=1, max_length=100)
+    field_type: FieldType = Field(...)  # single_line_text, number, date, boolean recommended
+    is_required: bool = False
+    sort_order: int = 0
+
+
+class KPIFieldSubFieldResponse(BaseModel):
+    """Sub-field in API response."""
+
+    id: int
+    field_id: int
+    name: str
+    key: str
+    field_type: FieldType
+    is_required: bool
+    sort_order: int
+
+    class Config:
+        from_attributes = True
+
+
 class KPIFieldOptionCreate(BaseModel):
     """Option for dropdown-style field."""
 
@@ -26,6 +55,7 @@ class KPIFieldCreate(BaseModel):
     sort_order: int = 0
     config: dict[str, Any] | None = None
     options: list[KPIFieldOptionCreate] = Field(default_factory=list)
+    sub_fields: list[KPIFieldSubFieldCreate] = Field(default_factory=list, description="For multi_line_items: column definitions")
 
 
 class KPIFieldUpdate(BaseModel):
@@ -39,6 +69,7 @@ class KPIFieldUpdate(BaseModel):
     sort_order: int | None = None
     config: dict[str, Any] | None = None
     options: list[KPIFieldOptionCreate] | None = None
+    sub_fields: list[KPIFieldSubFieldCreate] | None = Field(None, description="For multi_line_items: replace column definitions")
 
 
 class KPIFieldOptionResponse(BaseModel):
@@ -66,6 +97,7 @@ class KPIFieldResponse(BaseModel):
     sort_order: int
     config: dict[str, Any] | None
     options: list[KPIFieldOptionResponse] = []
+    sub_fields: list[KPIFieldSubFieldResponse] = []
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
- Introduced a new table `kpi_field_sub_fields` to define sub-fields for multi-line items in KPIs.
- Updated the `KPIField` model to include a relationship with `KPIFieldSubField`.
- Enhanced API routes and schemas to support creation, retrieval, and updating of sub-fields.
- Modified frontend components to handle sub-fields in forms and display.
- Implemented logic for managing sub-fields in the service layer, including deletion and updates.