### PR TITLE
Add chat functionality for KPI data

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,10 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/uni_kpi_mis
 # JWT (use a long random string in production)
 JWT_SECRET_KEY=change-me-in-production-use-long-random-string
 
+# Chat / NLP (optional; leave empty to disable chat)
+# OPENAI_API_KEY=sk-...
+# CHAT_MODEL=gpt-4o-mini
+
 # Optional
 # DEBUG=false
 # ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/backend/app/chat/__init__.py
+++ b/backend/app/chat/__init__.py
@@ -1,0 +1,1 @@
+"""Chat / NLP over KPI data for organization admins."""

--- a/backend/app/chat/routes.py
+++ b/backend/app/chat/routes.py
@@ -1,0 +1,33 @@
+"""Chat API routes (org admin only)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import require_org_admin, require_tenant
+from app.chat.schemas import ChatMessageRequest, ChatMessageResponse
+from app.chat.service import run_chat_turn
+from app.core.database import get_db
+from app.core.models import User
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+@router.post("/message", response_model=ChatMessageResponse)
+async def chat_message(
+    body: ChatMessageRequest,
+    current_user: User = Depends(require_org_admin),
+    _tenant: User = Depends(require_tenant),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Send a natural language query about organization KPI data.
+    Available to organization admins only. Returns NLP summary and source links to KPI entry pages.
+    """
+    org_id = current_user.organization_id
+    if not org_id:
+        return ChatMessageResponse(
+            text="You are not associated with an organization. Only organization admins can use chat.",
+            not_collected=False,
+        )
+    result = await run_chat_turn(db, org_id, body.message)
+    return ChatMessageResponse(**result)

--- a/backend/app/chat/schemas.py
+++ b/backend/app/chat/schemas.py
@@ -1,0 +1,40 @@
+"""Chat request/response schemas."""
+
+from pydantic import BaseModel, Field
+
+
+class ChatMessageRequest(BaseModel):
+    """Single user message for the chat endpoint."""
+
+    message: str = Field(..., min_length=1, max_length=4000)
+
+
+class ChatSource(BaseModel):
+    """Link to the KPI entry detail page: /dashboard/entries/kpi/{kpi_id}?year={year}&organization_id={organization_id}."""
+
+    kpi_id: int
+    kpi_name: str
+    year: int
+    organization_id: int
+
+
+class ChatMessageResponse(BaseModel):
+    """Response for one chat turn: NLP text, optional chart (e.g. year comparison), and source links."""
+
+    text: str = Field(..., description="Natural language reply to show the user")
+    sources: list[ChatSource] | None = Field(
+        None,
+        description="Links to KPI entry pages: /dashboard/entries/{kpi_id}/{year}",
+    )
+    chart: dict | None = Field(
+        None,
+        description="Optional chart for year-over-year comparison: { type, labels, series }",
+    )
+    not_entered: list[dict] | None = Field(
+        None,
+        description="KPIs with no data: [{ kpi_name, assigned_user_names }]",
+    )
+    not_collected: bool = Field(
+        False,
+        description="True if the question referred to KPIs/fields not in the system",
+    )

--- a/backend/app/chat/service.py
+++ b/backend/app/chat/service.py
@@ -1,0 +1,587 @@
+"""Chat service: schema context, OpenAI intent, data fetch, response formatting."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from datetime import datetime
+
+from app.core.config import get_settings
+from app.core.models import KPI, KPIField
+from app.entries.service import (
+    get_entries_for_kpis,
+    get_latest_year_with_entries,
+    get_available_years,
+)
+
+# Max schema size to keep prompts small
+MAX_KPIS_IN_SCHEMA = 50
+MAX_FIELDS_PER_KPI = 20
+
+# When user doesn't specify year we use latest year with data (see run_chat_turn)
+DEFAULT_YEAR_FALLBACK = 2024  # only if no entries exist at all
+
+# Limits for LLM and frontend to avoid token blow-up and bad UX
+MAX_ROWS_SENT_TO_LLM = 5
+MAX_TABLE_ROWS_DISPLAY = 15
+MAX_CELL_CHARS = 60
+MAX_YEARS_COMPARE = 6  # max years to include in year-over-year comparison
+
+
+def _get_openai_client() -> tuple["OpenAI | None", str]:
+    """Return (client, error_message). If client is None, error_message describes why."""
+    try:
+        from openai import OpenAI
+    except ImportError as e:
+        return None, f"OpenAI package not installed: {e}. Run: pip install openai"
+    settings = get_settings()
+    api_key = (settings.OPENAI_API_KEY or "").strip()
+    if not api_key:
+        return None, "OPENAI_API_KEY is empty in settings. Check your .env file and restart the server."
+    try:
+        client = OpenAI(api_key=api_key)
+        return client, ""
+    except Exception as e:
+        return None, f"OpenAI client init failed: {str(e)}"
+
+
+async def build_org_schema(db: AsyncSession, org_id: int) -> list[dict]:
+    """Build a compact schema of KPIs, fields, and sub-fields for the org (for LLM context)."""
+    q = (
+        select(KPI)
+        .where(KPI.organization_id == org_id)
+        .order_by(KPI.year.desc(), KPI.sort_order, KPI.name)
+        .limit(MAX_KPIS_IN_SCHEMA)
+        .options(
+            selectinload(KPI.fields).selectinload(KPIField.sub_fields),
+        )
+    )
+    result = await db.execute(q)
+    kpis = result.unique().scalars().all()
+    schema = []
+    for k in kpis:
+        fields = (k.fields or [])[:MAX_FIELDS_PER_KPI]
+        field_list = []
+        for f in fields:
+            sub_fields = getattr(f, "sub_fields", None) or []
+            sub_list = [{"key": sf.key, "name": sf.name} for sf in sub_fields[:15]]  # limit sub_fields per field
+            field_list.append({
+                "key": f.key,
+                "name": f.name,
+                "type": f.field_type.value,
+                "sub_fields": sub_list,
+            })
+        schema.append({
+            "id": k.id,
+            "name": k.name,
+            "year": k.year,
+            "fields": field_list,
+        })
+    return schema
+
+
+def _schema_to_text(schema: list[dict]) -> str:
+    """Turn schema list into a short text block for the prompt. Include sub-fields so NLP can match them."""
+    lines = []
+    for k in schema:
+        parts = []
+        for f in k["fields"]:
+            s = f"{f['key']} ({f['name']}, {f['type']})"
+            sub = f.get("sub_fields") or []
+            if sub:
+                sub_str = ", ".join(f"{sf['key']} ({sf['name']})" for sf in sub)
+                s += f" [sub_fields: {sub_str}]"
+            parts.append(s)
+        field_str = "; ".join(parts)
+        lines.append(f"KPI id={k['id']} name=\"{k['name']}\" year={k['year']} fields: {field_str}")
+    return "\n".join(lines)
+
+
+def _parse_intent_response(raw: str) -> dict | None:
+    """Parse LLM JSON response; extract intent, kpi_ids, field_keys, year, not_collected."""
+    raw = raw.strip()
+    # Try to find a JSON object in the response
+    match = re.search(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", raw, re.DOTALL)
+    if match:
+        raw = match.group(0)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    intent = data.get("intent") or "list_data"
+    if intent not in ("list_data", "summary", "comparison", "compare_years"):
+        intent = "list_data"
+    kpi_ids = data.get("kpi_ids")
+    if not isinstance(kpi_ids, list):
+        kpi_ids = [x for x in (data.get("kpi_id"),) if x is not None]
+    field_keys = data.get("field_keys")
+    if not isinstance(field_keys, list):
+        field_keys = []
+    year = data.get("year")
+    if year is not None and isinstance(year, (int, float)):
+        year = int(year)
+    else:
+        year = None
+    years = data.get("years")
+    if isinstance(years, list):
+        years = [int(y) for y in years if y is not None and isinstance(y, (int, float))][:MAX_YEARS_COMPARE]
+    else:
+        years = []
+    not_collected = bool(data.get("not_collected"))
+    return {
+        "intent": intent,
+        "kpi_ids": [int(x) for x in kpi_ids if x is not None],
+        "field_keys": [str(x) for x in field_keys if x],
+        "year": year,
+        "years": years,
+        "not_collected": not_collected,
+    }
+
+
+async def get_chat_intent(db: AsyncSession, org_id: int, user_message: str) -> tuple[dict | None, list[dict], str]:
+    """
+    Call OpenAI to get structured intent from user message. Returns (intent_dict, schema, error_message).
+    If error_message is non-empty, intent_dict may be None.
+    """
+    settings = get_settings()
+    if not (settings.OPENAI_API_KEY or "").strip():
+        return None, [], "Chat is not configured. Set OPENAI_API_KEY in the environment."
+
+    schema = await build_org_schema(db, org_id)
+    if not schema:
+        return None, [], "Your organization has no KPIs defined yet. Add KPIs first."
+
+    schema_text = _schema_to_text(schema)
+    valid_ids = [k["id"] for k in schema]
+    valid_keys = set()
+    for k in schema:
+        for f in k.get("fields", []):
+            valid_keys.add(f["key"])
+
+    system = f"""You are a KPI data assistant. The user's organization has the following KPI schema. Use only these IDs and field keys in your response.
+
+Schema:
+{schema_text}
+
+Respond with ONLY a JSON object (no markdown, no explanation) with:
+- "intent": one of "list_data", "summary", "comparison", or "compare_years". Use "compare_years" when the user asks to compare data across different years (e.g. "compare with previous years", "year over year", "2022 vs 2023 vs 2024", "how did it change over the years").
+- "kpi_ids": array of KPI ids from the schema that match the user question (use schema ids only)
+- "field_keys": optional array of field keys to include (from schema); if empty, include all fields
+- "year": integer year ONLY if the user explicitly mentions a single year; otherwise omit or null.
+- "years": optional array of years ONLY when intent is "compare_years" and the user specified which years (e.g. [2022, 2023, 2024]); otherwise omit so the system uses recent available years.
+
+When the user asks about data that appears in a sub_field (e.g. "titles", "author", "year" inside a list), match to the parent field that contains those sub_fields and include that field's key in "field_keys".
+If the user question does not match any KPI or field in the schema, set "kpi_ids" to [] and "not_collected" to true.
+Spelling and term normalization: interpret the user intent and map to the schema (e.g. "reaserch papers" -> KPI about research papers if it exists)."""
+
+    client, client_err = _get_openai_client()
+    if not client:
+        return None, schema, client_err or "OpenAI client could not be initialized."
+
+    try:
+        resp = client.chat.completions.create(
+            model=settings.CHAT_MODEL or "gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_message[:3000]},
+            ],
+            max_tokens=400,
+            temperature=0,
+        )
+        content = (resp.choices[0].message.content or "").strip()
+    except Exception as e:
+        return None, schema, f"Failed to call OpenAI: {str(e)}"
+
+    intent = _parse_intent_response(content)
+    if not intent:
+        return None, schema, "Could not understand the question. Try rephrasing or ask about a specific KPI."
+
+    # Validate intent against schema
+    intent["kpi_ids"] = [i for i in intent["kpi_ids"] if i in valid_ids]
+    intent["field_keys"] = [k for k in intent.get("field_keys", []) if k in valid_keys]
+    return intent, schema, ""
+
+
+def _truncate_cell(val: Any) -> str:
+    """Truncate cell value for sending to LLM to save tokens."""
+    s = str(val) if val is not None else ""
+    if len(s) > MAX_CELL_CHARS:
+        return s[: MAX_CELL_CHARS - 3] + "..."
+    return s
+
+
+def _get_nlp_summary(
+    client: Any,
+    user_message: str,
+    column_names: list[str],
+    row_count: int,
+    sample_rows: list[dict],
+    summary_numbers: dict[str, Any] | None,
+    data_year: int,
+    year_note: str,
+    model: str,
+) -> str:
+    """
+    Ask LLM for a short natural-language summary of the retrieved data. Use small payload only.
+    """
+    col_info = ", ".join(column_names) if column_names else "none"
+    # Build a tiny summary for the prompt: do not send many rows
+    data_desc = f"Total rows: {row_count}. Columns: {col_info}."
+    if summary_numbers:
+        data_desc += f" Summary numbers: {summary_numbers}."
+    if sample_rows:
+        # Truncate each cell
+        sample = []
+        for r in sample_rows:
+            sample.append({k: _truncate_cell(v) for k, v in r.items()})
+        data_desc += f" Sample rows (up to {len(sample)}): {json.dumps(sample, default=str)}."
+    prompt = f"""The user asked: "{user_message[:500]}"
+
+Retrieved KPI data for year {data_year}:
+{data_desc}
+{f"Note: {year_note}" if year_note else ""}
+
+Write a short, friendly answer (2-4 sentences) summarizing the data in natural language. Do not list all columns or repeat raw numbers verbatim; highlight what matters for the user's question. No preamble."""
+
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.3,
+        )
+        content = (resp.choices[0].message.content or "").strip()
+        return content or "Here is the retrieved data."
+    except Exception:
+        # Fallback: simple sentence
+        return f"Found {row_count} record(s) for {data_year}. " + (year_note or "")
+
+
+def _numeric_from_row(row: dict) -> float | None:
+    """Extract first numeric value from a row dict (for charts)."""
+    for v in (row or {}).values():
+        try:
+            if v is not None and str(v).strip() != "":
+                return float(str(v).replace(",", ""))
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+async def _run_compare_years(
+    db: AsyncSession,
+    org_id: int,
+    kpi_ids: list[int],
+    intent_years: list[int],
+    user_message: str,
+    name_by_id_from_schema: dict[int, str],
+) -> dict[str, Any]:
+    """Fetch data for multiple years, build chart and comparison text."""
+    # Resolve years to use (sorted ascending for chart)
+    if intent_years:
+        years = sorted(set(intent_years))[-MAX_YEARS_COMPARE:]
+    else:
+        years = await get_available_years(db, org_id, kpi_ids, limit=MAX_YEARS_COMPARE)
+        years = sorted(years, reverse=True)[:MAX_YEARS_COMPARE]
+        years = sorted(years)  # ascending for chart
+
+    if not years:
+        return {
+            "text": "No data found for the selected KPIs in any year. Enter data for at least one year to see a comparison.",
+            "sources": None,
+            "chart": None,
+            "not_entered": None,
+            "not_collected": False,
+        }
+
+    # Fetch entries per year; build (kpi_id, year) -> value (first numeric in row)
+    # and collect kpi_id -> kpi_name from rows
+    value_by_kpi_year: dict[int, dict[int, float]] = {kid: {} for kid in kpi_ids}
+    name_by_id: dict[int, str] = dict(name_by_id_from_schema)
+    kpis_with_any_data: set[int] = set()
+
+    for y in years:
+        rows, missing = await get_entries_for_kpis(db, org_id, kpi_ids, y)
+        for m in missing or []:
+            name_by_id[m["kpi_id"]] = m["kpi_name"]
+        for r in rows:
+            kid = r["kpi_id"]
+            kpis_with_any_data.add(kid)
+            name_by_id[kid] = r.get("kpi_name", name_by_id.get(kid, ""))
+            num = _numeric_from_row(r.get("row") or {})
+            value_by_kpi_year[kid][y] = num if num is not None else 0.0
+
+    # Sources: one per (kpi_id, year) for /dashboard/entries/kpi/{kpi_id}?year={y}&organization_id={org_id}
+    sources = [
+        {"kpi_id": kid, "kpi_name": name_by_id.get(kid, ""), "year": y, "organization_id": org_id}
+        for kid in kpi_ids
+        for y in years
+    ]
+
+    # Not entered: KPIs that have no data in any of the years
+    not_entered = None
+    missing_kpi_ids = [kid for kid in kpi_ids if kid not in kpis_with_any_data]
+    if missing_kpi_ids:
+        _, missing_list = await get_entries_for_kpis(db, org_id, missing_kpi_ids, years[-1])
+        not_entered = [
+            {"kpi_name": m["kpi_name"], "assigned_user_names": m.get("assigned_user_names", [])}
+            for m in (missing_list or [])
+        ]
+
+    # Comparison text: LLM or simple
+    text_parts = []
+    if not_entered:
+        for m in (not_entered or []):
+            names = m.get("assigned_user_names") or []
+            text_parts.append(
+                f"Data for \"{m.get('kpi_name', '')}\" has not been entered for any of the years. "
+                + (f"Responsible: {', '.join(names)}." if names else "")
+            )
+    # Build short summary for LLM: "Year 2022: KPI A = x, KPI B = y; Year 2023: ..."
+    summary_lines = []
+    for y in years:
+        parts = []
+        for kid in kpi_ids:
+            val = value_by_kpi_year.get(kid, {}).get(y, 0)
+            parts.append(f"{name_by_id.get(kid, '')}={val}")
+        summary_lines.append(f"{y}: " + ", ".join(parts))
+    data_summary = "; ".join(summary_lines)
+
+    client, _ = _get_openai_client()
+    if client:
+        try:
+            prompt = f"""The user asked: "{user_message[:400]}"
+
+Year-over-year data (same KPIs across years):
+{data_summary}
+
+Write a short comparison in 2-4 sentences: how values change across the years, and any notable trend. No preamble."""
+            resp = client.chat.completions.create(
+                model=get_settings().CHAT_MODEL or "gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=250,
+                temperature=0.3,
+            )
+            comp_text = (resp.choices[0].message.content or "").strip()
+            if comp_text:
+                text_parts.append(comp_text)
+        except Exception:
+            pass
+    if not text_parts or (len(text_parts) == 1 and not_entered):
+        text_parts.append(f"Comparison across {len(years)} year(s): {years[0]} to {years[-1]}. See the chart below for values by year.")
+    text = " ".join(text_parts)
+
+    return {
+        "text": text,
+        "sources": sources,
+        "chart": None,
+        "not_entered": not_entered,
+        "not_collected": False,
+    }
+
+
+async def run_chat_turn(
+    db: AsyncSession,
+    org_id: int,
+    user_message: str,
+) -> dict[str, Any]:
+    """
+    Execute one chat turn: resolve intent, fetch data, format response.
+    Returns a dict suitable for ChatMessageResponse (text, table, chart, summary_numbers, not_entered, not_collected).
+    """
+    intent, schema, err = await get_chat_intent(db, org_id, user_message)
+    if err:
+        return {
+            "text": err,
+            "sources": None,
+            "chart": None,
+            "not_entered": None,
+            "not_collected": False,
+        }
+
+    kpi_ids = intent.get("kpi_ids") or []
+    field_keys = intent.get("field_keys") or []
+    intent_year = intent.get("year")  # None if user did not specify year
+    intent_type = intent.get("intent") or "list_data"
+
+    # Resolve year: if user specified one use it; else use latest year that has data
+    current_year = datetime.now().year
+    if intent_year is not None:
+        year = intent_year
+        year_note = ""
+    else:
+        latest = await get_latest_year_with_entries(db, org_id, kpi_ids)
+        year = latest if latest is not None else current_year
+        if latest is not None and latest < current_year:
+            year_note = f"Data for {current_year} has not been entered yet. The following is for {year}."
+        else:
+            year_note = ""
+
+    # User asked about something not in schema
+    if not kpi_ids and intent.get("not_collected"):
+        return {
+            "text": "This information is not currently being collected by the system. Please contact the system administrator if you want this data to be collected.",
+            "sources": None,
+            "chart": None,
+            "not_entered": None,
+            "not_collected": True,
+        }
+
+    if not kpi_ids:
+        return {
+            "text": "I couldn't match your question to any KPI in your organization. Try referring to a KPI by name or field.",
+            "sources": None,
+            "chart": None,
+            "not_entered": None,
+            "not_collected": False,
+        }
+
+    # --- Multi-year comparison branch ---
+    if intent_type == "compare_years":
+        return await _run_compare_years(
+            db=db,
+            org_id=org_id,
+            kpi_ids=kpi_ids,
+            intent_years=intent.get("years") or [],
+            user_message=user_message,
+            name_by_id_from_schema={k["id"]: k["name"] for k in schema},
+        )
+
+    rows, missing_kpis = await get_entries_for_kpis(db, org_id, kpi_ids, year)
+
+    # Build not_entered for response
+    not_entered = None
+    if missing_kpis:
+        not_entered = [
+            {"kpi_name": m["kpi_name"], "assigned_user_names": m["assigned_user_names"]}
+            for m in missing_kpis
+        ]
+
+    # Filter columns if field_keys specified
+    if field_keys:
+        for r in rows:
+            r["row"] = {k: v for k, v in (r.get("row") or {}).items() if k in field_keys}
+
+    # Build table (list of row dicts) - use first KPI's row keys for headers
+    table = None
+    if rows:
+        all_keys = set()
+        for r in rows:
+            all_keys.update((r.get("row") or {}).keys())
+        # Prefer order: field_keys then rest
+        ordered_keys = [k for k in field_keys if k in all_keys]
+        for k in sorted(all_keys):
+            if k not in ordered_keys:
+                ordered_keys.append(k)
+        table = []
+        for r in rows:
+            row_dict = {"KPI": r.get("kpi_name", "")}
+            row_dict.update((r.get("row") or {}))
+            table.append(row_dict)
+
+    # Summary numbers (count; optional avg for numeric columns)
+    summary_numbers = None
+    if rows:
+        summary_numbers = {"Number of records": len(rows)}
+        # If single KPI and numeric-looking fields, add simple aggregates
+        if len(kpi_ids) == 1 and table:
+            for col in list(table[0].keys()):
+                if col == "KPI":
+                    continue
+                vals = [table[i].get(col) for i in range(len(table))]
+                numeric = []
+                for v in vals:
+                    try:
+                        if v is not None and str(v).strip() != "":
+                            numeric.append(float(str(v).replace(",", "")))
+                    except (ValueError, TypeError):
+                        pass
+                if numeric:
+                    summary_numbers[f"Sum ({col})"] = round(sum(numeric), 2)
+                    summary_numbers[f"Average ({col})"] = round(sum(numeric) / len(numeric), 2)
+
+    # Chart: only for comparison with a few series
+    chart = None
+    if intent_type == "comparison" and rows and len(rows) <= 20:
+        # Simple bar: KPI name or first text field as label, first numeric as value
+        labels = []
+        values = []
+        for r in rows:
+            labels.append(r.get("kpi_name", "")[:30])
+            row = r.get("row") or {}
+            num = None
+            for v in row.values():
+                try:
+                    num = float(str(v).replace(",", ""))
+                    break
+                except (ValueError, TypeError):
+                    pass
+            values.append(num if num is not None else 0)
+        if labels and values:
+            chart = {"type": "bar", "labels": labels, "series": [{"name": "Value", "data": values}]}
+
+    # Source links: /dashboard/entries/kpi/{kpi_id}?year={year}&organization_id={org_id}
+    name_by_id: dict[int, str] = {r["kpi_id"]: r["kpi_name"] for r in rows}
+    for m in missing_kpis or []:
+        name_by_id[m["kpi_id"]] = m["kpi_name"]
+    sources = [
+        {"kpi_id": kid, "kpi_name": name_by_id.get(kid, ""), "year": year, "organization_id": org_id}
+        for kid in kpi_ids
+    ]
+
+    # Main response text: get NLP summary from LLM when we have data (don't send many rows)
+    text_parts = []
+    if not_entered:
+        for m in missing_kpis:
+            names = m.get("assigned_user_names") or []
+            if names:
+                text_parts.append(
+                    f"Data for \"{m.get('kpi_name', '')}\" has not been entered yet. "
+                    f"The following user(s) are responsible for entering it: {', '.join(names)}."
+                )
+            else:
+                text_parts.append(f"Data for \"{m.get('kpi_name', '')}\" has not been entered yet.")
+    if year_note:
+        text_parts.append(year_note)
+
+    if rows:
+        client, client_err = _get_openai_client()
+        if client and table:
+            column_names = list(table[0].keys()) if table else []
+            sample_for_llm = table[:MAX_ROWS_SENT_TO_LLM]
+            nlp_text = _get_nlp_summary(
+                client=client,
+                user_message=user_message,
+                column_names=column_names,
+                row_count=len(table),
+                sample_rows=sample_for_llm,
+                summary_numbers=summary_numbers,
+                data_year=year,
+                year_note=year_note,
+                model=get_settings().CHAT_MODEL or "gpt-4o-mini",
+            )
+            text_parts.append(nlp_text)
+        else:
+            # Fallback without LLM
+            if intent_type == "summary" and summary_numbers:
+                text_parts.append("Summary: " + "; ".join(f"{k}: {v}" for k, v in summary_numbers.items()))
+            elif intent_type == "comparison" and chart:
+                text_parts.append(f"Comparison of {len(rows)} KPI entries for {year} (see chart below).")
+            else:
+                text_parts.append(f"Found {len(rows)} record(s) for the selected KPIs for year {year}.")
+    if not text_parts:
+        text_parts.append("No data found for the selected KPIs and year.")
+
+    return {
+        "text": " ".join(text_parts),
+        "sources": sources,
+        "chart": None,
+        "not_entered": not_entered,
+        "not_collected": False,
+    }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,13 @@
 """Application configuration loaded from environment."""
 
-from pydantic_settings import BaseSettings
+from pathlib import Path
 from functools import lru_cache
+
+from pydantic_settings import BaseSettings
+
+# Load .env from backend directory so it works when running from project root or backend/
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+_ENV_FILE = _BACKEND_DIR / ".env"
 
 
 class Settings(BaseSettings):
@@ -23,8 +29,12 @@ class Settings(BaseSettings):
     # CORS
     CORS_ORIGINS: list[str] = ["http://localhost:3000"]
 
+    # Chat / NLP (OpenAI)
+    OPENAI_API_KEY: str = ""
+    CHAT_MODEL: str = "gpt-4o-mini"
+
     class Config:
-        env_file = ".env"
+        env_file = _ENV_FILE
         case_sensitive = True
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.org_tags.routes import router as org_tags_router
 from app.fields.routes import router as fields_router
 from app.entries.routes import router as entries_router
 from app.reports.routes import router as reports_router
+from app.chat.routes import router as chat_router
 
 settings = get_settings()
 
@@ -41,6 +42,7 @@ app.include_router(org_tags_router, prefix="/api/organizations")
 app.include_router(fields_router, prefix="/api")
 app.include_router(entries_router, prefix="/api")
 app.include_router(reports_router, prefix="/api")
+app.include_router(chat_router, prefix="/api")
 
 
 @app.get("/health")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,6 @@ python-dotenv==1.0.1
 Jinja2==3.1.3
 openpyxl==3.1.5
 httpx>=0.27.0
+
+# Chat / NLP
+openai>=1.12.0

--- a/frontend/src/app/dashboard/chat/page.tsx
+++ b/frontend/src/app/dashboard/chat/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { getAccessToken } from "@/lib/auth";
+import { api } from "@/lib/api";
+
+interface ChatSource {
+  kpi_id: number;
+  kpi_name: string;
+  year: number;
+  organization_id: number;
+}
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  sources?: ChatSource[] | null;
+  not_entered?: { kpi_name: string; assigned_user_names: string[] }[];
+  not_collected?: boolean;
+}
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || loading) return;
+    setInput("");
+    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", text };
+    setMessages((prev) => [...prev, userMsg]);
+    setLoading(true);
+    try {
+      const token = getAccessToken();
+      const res = await api<{
+        text: string;
+        sources?: ChatSource[] | null;
+        not_entered?: { kpi_name: string; assigned_user_names: string[] }[];
+        not_collected: boolean;
+      }>("/chat/message", {
+        method: "POST",
+        body: JSON.stringify({ message: text }),
+        token: token || undefined,
+      });
+      const assistantMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        text: res.text,
+        sources: res.sources ?? undefined,
+        not_entered: res.not_entered ?? undefined,
+        not_collected: res.not_collected ?? false,
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (e) {
+      const errMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        text: e instanceof Error ? e.message : "Something went wrong. Please try again.",
+      };
+      setMessages((prev) => [...prev, errMsg]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", maxWidth: 900, margin: "0 auto", height: "calc(100vh - 120px)", minHeight: 400 }}>
+      <h1 style={{ fontSize: "1.25rem", marginBottom: "0.75rem", color: "var(--text)" }}>
+        Chat with your KPI data
+      </h1>
+      <p style={{ fontSize: "0.9rem", color: "var(--muted)", marginBottom: "1rem" }}>
+        Ask in natural language (e.g. &quot;How many research papers in 2024?&quot;, &quot;Compare enrollment with previous years&quot;).
+      </p>
+
+      <div
+        style={{
+          flex: 1,
+          overflow: "auto",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          background: "var(--surface)",
+          padding: "1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+        }}
+      >
+        {messages.length === 0 && (
+          <div style={{ color: "var(--muted)", fontSize: "0.9rem", textAlign: "center", padding: "2rem" }}>
+            Send a message to get started.
+          </div>
+        )}
+        {messages.map((m) => (
+          <div
+            key={m.id}
+            style={{
+              alignSelf: m.role === "user" ? "flex-end" : "flex-start",
+              maxWidth: "85%",
+              padding: "0.75rem 1rem",
+              borderRadius: 8,
+              background: m.role === "user" ? "var(--accent)" : "var(--bg-subtle)",
+              color: m.role === "user" ? "#fff" : "var(--text)",
+            }}
+          >
+            <div style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{m.text}</div>
+            {m.role === "assistant" && m.not_collected && (
+              <div style={{ marginTop: "0.5rem", fontSize: "0.85rem", color: "var(--warning)" }}>
+                This information is not currently collected. Contact the system administrator.
+              </div>
+            )}
+            {m.role === "assistant" && m.not_entered && m.not_entered.length > 0 && (
+              <div style={{ marginTop: "0.5rem", fontSize: "0.85rem" }}>
+                {m.not_entered.map((n, i) => (
+                  <div key={i} style={{ color: "var(--warn)" }}>
+                    Data for &quot;{n.kpi_name}&quot; not entered yet.
+                    {n.assigned_user_names?.length ? ` Responsible: ${n.assigned_user_names.join(", ")}.` : ""}
+                  </div>
+                ))}
+              </div>
+            )}
+            {m.role === "assistant" && m.sources && m.sources.length > 0 && (
+              <div style={{ marginTop: "0.75rem", fontSize: "0.85rem" }}>
+                <span style={{ color: "var(--muted)", marginRight: "0.35rem" }}>Source:</span>
+                {m.sources.map((s) => (
+                  <Link
+                    key={`${s.kpi_id}-${s.year}`}
+                    href={`/dashboard/entries/kpi/${s.kpi_id}?year=${s.year}&organization_id=${s.organization_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      display: "inline-block",
+                      marginRight: "0.5rem",
+                      marginTop: "0.25rem",
+                      color: "var(--accent)",
+                      textDecoration: "none",
+                    }}
+                  >
+                    {s.kpi_name} ({s.year}) →
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+        {loading && (
+          <div style={{ alignSelf: "flex-start", padding: "0.75rem 1rem", color: "var(--muted)", fontSize: "0.9rem" }}>
+            Thinking…
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          send();
+        }}
+        style={{
+          display: "flex",
+          gap: "0.5rem",
+          marginTop: "0.75rem",
+        }}
+      >
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask about your KPI data..."
+          disabled={loading}
+          style={{
+            flex: 1,
+            padding: "0.6rem 0.75rem",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            fontSize: "0.95rem",
+          }}
+        />
+        <button
+          type="submit"
+          disabled={loading || !input.trim()}
+          style={{
+            padding: "0.6rem 1rem",
+            background: "var(--accent)",
+            color: "#fff",
+            border: "none",
+            borderRadius: 8,
+            fontWeight: 600,
+            cursor: loading || !input.trim() ? "not-allowed" : "pointer",
+            opacity: loading || !input.trim() ? 0.7 : 1,
+          }}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
+++ b/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
@@ -120,6 +120,8 @@ export default function DomainKpiDetailPage() {
   const [fetchingFromApi, setFetchingFromApi] = useState(false);
   const [syncFeedback, setSyncFeedback] = useState<string | null>(null);
   const [bulkMethod, setBulkMethod] = useState<"upload" | "api">("upload");
+  /** Bulk upload section is hidden until user clicks the "Bulk upload" link (per multi_line field) */
+  const [bulkExpandedByFieldId, setBulkExpandedByFieldId] = useState<Record<number, boolean>>({});
 
   type FormCell = { value_text?: string; value_number?: number; value_boolean?: boolean; value_date?: string; value_json?: Record<string, unknown>[] };
   const [formValues, setFormValues] = useState<Record<number, FormCell>>({});
@@ -643,6 +645,28 @@ export default function DomainKpiDetailPage() {
                 <p style={{ color: "var(--muted)" }}>No sub-fields defined.</p>
               ) : (
                 <>
+                  <div style={{ marginBottom: "0.75rem", display: "flex", alignItems: "center", gap: "0.5rem", flexWrap: "wrap" }}>
+                    <button
+                      type="button"
+                      onClick={() => setBulkExpandedByFieldId((prev) => ({ ...prev, [f.id]: !prev[f.id] }))}
+                      style={{
+                        padding: "0.35rem 0.5rem",
+                        border: "1px solid var(--border)",
+                        borderRadius: 6,
+                        background: "var(--surface)",
+                        fontSize: "0.85rem",
+                        cursor: "pointer",
+                        minWidth: 32,
+                      }}
+                      title={bulkExpandedByFieldId[f.id] ? "Collapse" : "Expand"}
+                    >
+                      {bulkExpandedByFieldId[f.id] ? "▲" : "▼"}
+                    </button>
+                    <span style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-secondary)" }}>
+                      Bulk upload
+                    </span>
+                  </div>
+                  {bulkExpandedByFieldId[f.id] && (
                   <div
                     className="card"
                     style={{
@@ -652,10 +676,26 @@ export default function DomainKpiDetailPage() {
                       border: "1px solid var(--border)",
                     }}
                   >
-                    <div style={{ marginBottom: "0.75rem" }}>
-                      <label style={{ display: "block", fontSize: "0.85rem", fontWeight: 600, marginBottom: "0.35rem", color: "var(--text-secondary)" }}>
-                        Bulk load data
-                      </label>
+                    <div style={{ marginBottom: "0.75rem", display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+                      {bulkMethod === "api" && kpiApiInfo?.api_endpoint_url && (
+                        <a
+                          href={kpiApiInfo.api_endpoint_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style={{
+                            fontSize: "0.9rem",
+                            color: "var(--accent)",
+                            textDecoration: "none",
+                            maxWidth: "100%",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                          title={kpiApiInfo.api_endpoint_url}
+                        >
+                          {kpiApiInfo.api_endpoint_url}
+                        </a>
+                      )}
                       <select
                         value={isApiKpi ? bulkMethod : "upload"}
                         onChange={(e) => setBulkMethod(e.target.value as "upload" | "api")}
@@ -805,6 +845,7 @@ export default function DomainKpiDetailPage() {
                       </div>
                     )}
                   </div>
+                  )}
 
                   {isEditing && (
                     <div style={{ marginBottom: "0.75rem" }}>

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -14,6 +14,7 @@ import {
   canManageDomains,
   canEnterData,
   canViewReports,
+  canUseChat,
 } from "@/lib/auth";
 
 const currentYear = new Date().getFullYear();
@@ -129,6 +130,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   };
 
   const hamburgerItems: { href: string; label: string; show: boolean }[] = [
+    { href: "/dashboard/chat", label: "Chat with data", show: canUseChat(role) },
     { href: "/dashboard/reports", label: "Reports", show: !isSuperAdmin && !isDataEntryOnlyUser && canViewReports(role) },
     { href: "/dashboard/users", label: "Users", show: !isSuperAdmin && canManageUsers(role) },
   ].filter((x) => x.show);

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -66,3 +66,8 @@ export function canEnterData(role: UserRole): boolean {
 export function canViewReports(role: UserRole): boolean {
   return role === "REPORT_VIEWER" || role === "ORG_ADMIN" || role === "SUPER_ADMIN" || role === "USER";
 }
+
+/** Chat with KPI data (NLP) is for organization admins only. */
+export function canUseChat(role: UserRole): boolean {
+  return role === "ORG_ADMIN" || role === "SUPER_ADMIN";
+}


### PR DESCRIPTION
- Introduced a new chat feature allowing organization admins to interact with KPI data using natural language queries.
- Added new API routes for chat messages, enabling users to send queries and receive NLP-generated responses.
- Implemented chat request and response schemas to structure the data exchanged between the frontend and backend.
- Updated the frontend to include a chat interface, allowing users to ask questions and view responses in real-time.
- Enhanced backend configuration to support OpenAI integration for NLP capabilities, including environment variable setup for API keys.
- Included necessary dependencies in requirements for chat functionality.