### PR TITLE
Add multi_reference field type and associated functionality

### DIFF
--- a/backend/alembic/versions/030_fieldtype_multi_reference.py
+++ b/backend/alembic/versions/030_fieldtype_multi_reference.py
@@ -1,0 +1,26 @@
+"""Add multi_reference value to fieldtype enum.
+
+Revision ID: 030_fieldtype_multi_ref
+Revises: 029_fieldtype_attachment
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "030_fieldtype_multi_ref"
+down_revision: Union[str, None] = "029_fieldtype_attachment"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    try:
+        op.execute("ALTER TYPE fieldtype ADD VALUE 'multi_reference'")
+    except Exception:
+        pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/core/models.py
+++ b/backend/app/core/models.py
@@ -45,7 +45,7 @@ class FieldType(str, enum.Enum):
     multi_line_items = "multi_line_items"
     formula = "formula"
     reference = "reference"  # Reference/Lookup: values from another KPI field
-
+    multi_reference = "multi_reference"  # Multiple lookup values from one linked KPI field (stored as JSON list)
 
 class TimeDimension(str, enum.Enum):
     """Time granularity: multi_year, yearly, half_yearly, quarterly, monthly."""

--- a/backend/app/entries/routes.py
+++ b/backend/app/entries/routes.py
@@ -302,6 +302,8 @@ async def upload_multi_items_excel(
         get_reference_allowed_values,
         _normalize_reference_value,
         _is_reference_empty_or_sentinel,
+        coerce_multi_reference_raw,
+        filter_multi_reference_to_allowed,
     )
     validation_errors: list[dict] = []
     ref_sub_fields = [s for s in (field.sub_fields or []) if getattr(s, "field_type", None) == FieldType.reference]
@@ -340,6 +342,57 @@ async def upload_multi_items_excel(
                         "message": "Value does not exist in the referenced KPI field.",
                     }
                 )
+    multif_sub_fields = [
+        s for s in (field.sub_fields or []) if getattr(s, "field_type", None) == FieldType.multi_reference
+    ]
+    multif_allowed_list: dict[tuple[int, str, str | None], list[str]] = {}
+    for row_idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        for sf in multif_sub_fields:
+            cfg = getattr(sf, "config", None) or {}
+            sid = cfg.get("reference_source_kpi_id")
+            skey = cfg.get("reference_source_field_key")
+            subkey = cfg.get("reference_source_sub_field_key")
+            if not sid or not skey:
+                continue
+            cache_key = (int(sid), str(skey), str(subkey) if subkey else None)
+            if cache_key not in multif_allowed_list:
+                multif_allowed_list[cache_key] = await get_reference_allowed_values(
+                    db, int(sid), str(skey), org_id, source_sub_field_key=(str(subkey) if subkey else None)
+                )
+            allowed_list = multif_allowed_list[cache_key]
+            allowed_norm = {_normalize_reference_value(a) for a in allowed_list}
+            cell = item.get(sf.key)
+            for tok in coerce_multi_reference_raw(cell):
+                if isinstance(tok, dict):
+                    s = None
+                    for k in ("label", "text", "value", "name"):
+                        if k in tok and tok[k] is not None:
+                            s = str(tok[k])
+                            break
+                    if s is None:
+                        continue
+                else:
+                    s = str(tok) if tok is not None else ""
+                n = _normalize_reference_value(s)
+                if _is_reference_empty_or_sentinel(n):
+                    continue
+                if n not in allowed_norm:
+                    validation_errors.append(
+                        {
+                            "field_key": field.key,
+                            "sub_field_key": sf.key,
+                            "row_index": row_idx,
+                            "value": str(cell),
+                            "row": item,
+                            "message": "One or more values do not exist in the referenced KPI field.",
+                        }
+                    )
+                    break
+            else:
+                cleaned = filter_multi_reference_to_allowed(cell, allowed_list) if allowed_list else []
+                item[sf.key] = cleaned if cleaned else None
     if validation_errors:
         raise EntryValidationError(validation_errors)
 
@@ -1272,6 +1325,7 @@ def _build_kpi_entry_xlsx(
         FieldType.attachment,
         FieldType.formula,
         FieldType.reference,
+        FieldType.multi_reference,
     )
     scalar_fields = [f for f in fields if getattr(f, "field_type", None) in scalar_types]
     ws_scalar = wb.active
@@ -1282,7 +1336,10 @@ def _build_kpi_entry_xlsx(
         if fv is None:
             ws_scalar.append([f.name, ""])
             continue
-        if fv.value_text is not None:
+        ft = getattr(f, "field_type", None)
+        if ft == FieldType.multi_reference and isinstance(fv.value_json, list):
+            val = "; ".join(str(x) for x in fv.value_json)
+        elif fv.value_text is not None:
             val = fv.value_text
         elif fv.value_number is not None:
             val = fv.value_number
@@ -1310,11 +1367,20 @@ def _build_kpi_entry_xlsx(
         ws.append(keys)
         fv = value_by_field_id.get(f.id)
         rows = list(fv.value_json) if (fv and isinstance(getattr(fv, "value_json", None), list)) else []
+        key_to_sf = {s.key: s for s in sub_fields}
         for row in rows:
             if not isinstance(row, dict):
                 ws.append([""] * len(keys))
                 continue
-            ws.append([row.get(k, "") for k in keys])
+
+            def _cell_out(col_key: str):
+                raw = row.get(col_key, "")
+                sf = key_to_sf.get(col_key)
+                if sf and getattr(sf, "field_type", None) == FieldType.multi_reference and isinstance(raw, list):
+                    return "; ".join(str(x) for x in raw)
+                return raw if raw is not None else ""
+
+            ws.append([_cell_out(k) for k in keys])
 
     buf = BytesIO()
     wb.save(buf)
@@ -1376,6 +1442,8 @@ def _parse_kpi_entry_xlsx(
     """Parse uploaded Excel into field values. Returns {field_id: {value_text, value_number, value_boolean, value_date, value_json}}."""
     from openpyxl import load_workbook
 
+    from app.entries.service import coerce_multi_reference_raw
+
     wb = load_workbook(filename=BytesIO(content), data_only=True)
     result: dict[int, dict] = {}
 
@@ -1433,6 +1501,9 @@ def _parse_kpi_entry_xlsx(
                         val["value_text"] = str(raw_value)
                 else:
                     val["value_text"] = str(raw_value)
+            elif ft == FieldType.multi_reference:
+                parsed = coerce_multi_reference_raw(str(raw_value) if raw_value is not None else "")
+                val["value_json"] = parsed if parsed else None
             else:
                 val["value_text"] = str(raw_value) if raw_value is not None else None
             result[field.id] = val
@@ -1503,6 +1574,9 @@ def _parse_kpi_entry_xlsx(
                             item[key] = str(raw)
                     else:
                         item[key] = str(raw)
+                elif sf_type == FieldType.multi_reference or sf_type == "multi_reference":
+                    parsed = coerce_multi_reference_raw(str(raw) if raw is not None else "")
+                    item[key] = parsed if parsed else None
                 else:
                     item[key] = str(raw)
             if not empty:
@@ -1569,6 +1643,29 @@ async def import_entry_excel(
     await db.commit()
     await db.refresh(entry)
     return {"message": "Import successful", "entry_id": entry.id, "fields_updated": len(values)}
+
+
+def _reverse_ref_tokens_from_cell(cell) -> list[tuple[str, str]]:
+    """Return (display_label, normalized_token) pairs for reverse-reference matching."""
+    if cell is None or cell == "":
+        return []
+    out: list[tuple[str, str]] = []
+    if isinstance(cell, list):
+        for x in cell:
+            if x is None:
+                continue
+            label = str(x).strip()
+            if not label:
+                continue
+            t = _normalize_reference_value(label)
+            if t:
+                out.append((label, t))
+        return out
+    label = str(cell).strip()
+    t = _normalize_reference_value(label)
+    if t:
+        out.append((label, t))
+    return out
 
 
 @router.get("/reverse-references")
@@ -1672,7 +1769,7 @@ async def get_reverse_references_for_entry(
     descriptors_by_child_kpi: dict[int, list[dict]] = {}
     for f in all_fields:
         for sf in getattr(f, "sub_fields", []) or []:
-            if getattr(sf, "field_type", None) != FieldType.reference:
+            if getattr(sf, "field_type", None) not in (FieldType.reference, FieldType.multi_reference):
                 continue
             cfg = getattr(sf, "config", None) or {}
             sid = cfg.get("reference_source_kpi_id")
@@ -1732,29 +1829,33 @@ async def get_reverse_references_for_entry(
                     if not isinstance(row, dict):
                         continue
                     cell = row.get(p_sub)
-                    if cell is None or cell == "":
-                        continue
-                    label = (str(cell)).strip()
-                    token = _normalize_reference_value(label)
-                    if not token:
-                        continue
-                    descriptor_tokens.setdefault(token, {"label": label})
-            else:
-                # Scalar parent field: use its primary value_text/number/boolean/date
-                raw_val = None
-                if fv.value_text not in (None, ""):
-                    raw_val = fv.value_text
-                elif fv.value_number is not None:
-                    raw_val = fv.value_number
-                elif fv.value_boolean is not None:
-                    raw_val = fv.value_boolean
-                elif fv.value_date is not None:
-                    raw_val = fv.value_date.isoformat()
-                if raw_val is not None:
-                    label = (str(raw_val)).strip()
-                    token = _normalize_reference_value(label)
-                    if token:
+                    for label, token in _reverse_ref_tokens_from_cell(cell):
                         descriptor_tokens.setdefault(token, {"label": label})
+            else:
+                p_ft = getattr(parent_field, "field_type", None)
+                if p_ft == FieldType.multi_reference:
+                    arr = fv.value_json if isinstance(fv.value_json, list) else []
+                    for x in arr:
+                        label = str(x).strip() if x is not None else ""
+                        token = _normalize_reference_value(label)
+                        if token:
+                            descriptor_tokens.setdefault(token, {"label": label})
+                else:
+                    # Scalar parent field: use its primary value_text/number/boolean/date
+                    raw_val = None
+                    if fv.value_text not in (None, ""):
+                        raw_val = fv.value_text
+                    elif fv.value_number is not None:
+                        raw_val = fv.value_number
+                    elif fv.value_boolean is not None:
+                        raw_val = fv.value_boolean
+                    elif fv.value_date is not None:
+                        raw_val = fv.value_date.isoformat()
+                    if raw_val is not None:
+                        label = (str(raw_val)).strip()
+                        token = _normalize_reference_value(label)
+                        if token:
+                            descriptor_tokens.setdefault(token, {"label": label})
 
         if not descriptor_tokens:
             continue
@@ -1797,29 +1898,26 @@ async def get_reverse_references_for_entry(
                     if not isinstance(row, dict):
                         continue
                     cell = row.get(child_sub_key)
-                    if cell is None or cell == "":
-                        continue
-                    label = (str(cell)).strip()
-                    token = _normalize_reference_value(label)
-                    if token not in tokens_set:
-                        continue
-                    token_counts[token] = token_counts.get(token, 0) + 1
-                    rows_payload.append(
-                        {
-                            "entry_id": entry.id,
-                            "year": entry.year,
-                            "period_key": getattr(entry, "period_key", "") or "",
-                            "value_token": token,
-                            "value_display": label,
-                            "child_field_id": child_field_id,
-                            "child_field_key": d["child_field_key"],
-                            "child_field_name": d["child_field_name"],
-                            "child_sub_field_key": child_sub_key,
-                            "child_sub_field_name": d["child_sub_field_name"],
-                            "row_index": idx,
-                            "row": row,
-                        }
-                    )
+                    for label, token in _reverse_ref_tokens_from_cell(cell):
+                        if token not in tokens_set:
+                            continue
+                        token_counts[token] = token_counts.get(token, 0) + 1
+                        rows_payload.append(
+                            {
+                                "entry_id": entry.id,
+                                "year": entry.year,
+                                "period_key": getattr(entry, "period_key", "") or "",
+                                "value_token": token,
+                                "value_display": label,
+                                "child_field_id": child_field_id,
+                                "child_field_key": d["child_field_key"],
+                                "child_field_name": d["child_field_name"],
+                                "child_sub_field_key": child_sub_key,
+                                "child_sub_field_name": d["child_sub_field_name"],
+                                "row_index": idx,
+                                "row": row,
+                            }
+                        )
 
         # Only include child KPI if we found any rows
         if not rows_payload:

--- a/backend/app/entries/service.py
+++ b/backend/app/entries/service.py
@@ -1,6 +1,8 @@
 """KPI entry CRUD, submit, lock; formula evaluation for formula fields."""
 
+import json
 from datetime import datetime
+from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, distinct
 from sqlalchemy.orm import selectinload
@@ -160,6 +162,67 @@ _REFERENCE_EMPTY_SENTINELS = frozenset(
 def _is_reference_empty_or_sentinel(normalized: str) -> bool:
     """True if the value should be accepted for reference validation without checking the allowed list."""
     return not normalized or normalized.lower().strip() in _REFERENCE_EMPTY_SENTINELS
+
+
+def coerce_multi_reference_raw(raw: Any) -> list[Any]:
+    """Normalize client/Excel input into a list of raw tokens (strings or JSON-like)."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return []
+        if s.startswith("["):
+            try:
+                parsed = json.loads(s)
+                if isinstance(parsed, list):
+                    return parsed
+                return [parsed]
+            except (json.JSONDecodeError, TypeError):
+                pass
+        if ";" in s:
+            return [p.strip() for p in s.split(";") if p.strip()]
+        return [p.strip() for p in s.split(",") if p.strip()]
+    return [raw]
+
+
+def _canonical_by_normalized_reference(allowed: list[str]) -> dict[str, str]:
+    """Map normalized token -> first canonical display string from allowed list."""
+    out: dict[str, str] = {}
+    for a in allowed:
+        n = _normalize_reference_value(str(a))
+        if n and n not in out:
+            out[n] = str(a).strip()
+    return out
+
+
+def filter_multi_reference_to_allowed(raw: Any, allowed: list[str]) -> list[str]:
+    """Keep only values that match the reference allowed list (canonical casing). Dedupe."""
+    norm_map = _canonical_by_normalized_reference(allowed)
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in coerce_multi_reference_raw(raw):
+        if isinstance(item, dict):
+            s = None
+            for k in ("label", "text", "value", "name"):
+                if k in item and item[k] is not None:
+                    s = str(item[k])
+                    break
+            if s is None:
+                continue
+        else:
+            s = str(item) if item is not None else ""
+        n = _normalize_reference_value(s)
+        if _is_reference_empty_or_sentinel(n):
+            continue
+        if n in norm_map:
+            canon = norm_map[n]
+            if canon not in seen:
+                seen.add(canon)
+                out.append(canon)
+    return out
 
 
 async def _get_entry(db: AsyncSession, entry_id: int, org_id: int) -> KPIEntry | None:
@@ -788,28 +851,58 @@ async def save_entry_values(
                     # isn't found in the resolved reference list, coerce it to null instead of failing.
                     if not allowed_normalized or normalized not in allowed_normalized:
                         v.value_text = None
+        elif f.field_type == FieldType.multi_reference:
+            config = getattr(f, "config", None) or {}
+            sid = config.get("reference_source_kpi_id")
+            skey = config.get("reference_source_field_key")
+            sub_key = config.get("reference_source_sub_field_key")
+            v.value_text = None
+            if sid and skey:
+                allowed = await get_reference_allowed_values(db, int(sid), str(skey), org_id, source_sub_field_key=sub_key)
+                if not allowed:
+                    v.value_json = None
+                else:
+                    cleaned = filter_multi_reference_to_allowed(
+                        v.value_json if v.value_json is not None else v.value_text,
+                        allowed,
+                    )
+                    v.value_json = cleaned if cleaned else None
+            else:
+                v.value_json = None
         elif f.field_type == FieldType.multi_line_items and isinstance(v.value_json, list):
             for sub in getattr(f, "sub_fields", []) or []:
-                if getattr(sub, "field_type", None) != FieldType.reference:
-                    continue
+                ft = getattr(sub, "field_type", None)
                 config = getattr(sub, "config", None) or {}
                 sid = config.get("reference_source_kpi_id")
                 skey = config.get("reference_source_field_key")
                 sub_key = config.get("reference_source_sub_field_key")
                 if not sid or not skey:
                     continue
-                allowed = await get_reference_allowed_values(db, int(sid), str(skey), org_id, source_sub_field_key=sub_key)
-                allowed_normalized = {_normalize_reference_value(a) for a in allowed}
-                for row_idx, row in enumerate(v.value_json):
-                    if not isinstance(row, dict):
+                if ft == FieldType.reference:
+                    allowed = await get_reference_allowed_values(db, int(sid), str(skey), org_id, source_sub_field_key=sub_key)
+                    allowed_normalized = {_normalize_reference_value(a) for a in allowed}
+                    for row in v.value_json:
+                        if not isinstance(row, dict):
+                            continue
+                        cell = row.get(sub.key)
+                        raw = cell if isinstance(cell, str) else str(cell) if cell is not None else ""
+                        normalized = _normalize_reference_value(raw)
+                        if not _is_reference_empty_or_sentinel(normalized):
+                            if not allowed_normalized or normalized not in allowed_normalized:
+                                row[sub.key] = None
+                elif ft == FieldType.multi_reference:
+                    allowed = await get_reference_allowed_values(db, int(sid), str(skey), org_id, source_sub_field_key=sub_key)
+                    if not allowed:
+                        for row in v.value_json:
+                            if isinstance(row, dict) and sub.key in row:
+                                row[sub.key] = None
                         continue
-                    cell = row.get(sub.key)
-                    raw = cell if isinstance(cell, str) else str(cell) if cell is not None else ""
-                    normalized = _normalize_reference_value(raw)
-                    if not _is_reference_empty_or_sentinel(normalized):
-                        if not allowed_normalized or normalized not in allowed_normalized:
-                            # Mark unresolved references as null for linked/mapped fields.
-                            row[sub.key] = None
+                    for row in v.value_json:
+                        if not isinstance(row, dict):
+                            continue
+                        cell = row.get(sub.key)
+                        cleaned = filter_multi_reference_to_allowed(cell, allowed)
+                        row[sub.key] = cleaned if cleaned else None
 
     if validation_errors:
         raise EntryValidationError(validation_errors)

--- a/backend/app/fields/schemas.py
+++ b/backend/app/fields/schemas.py
@@ -13,6 +13,7 @@ SUB_FIELD_TYPES = (
     FieldType.date,
     FieldType.boolean,
     FieldType.reference,
+    FieldType.multi_reference,
     FieldType.attachment,
 )
 
@@ -22,7 +23,7 @@ class KPIFieldSubFieldCreate(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=255)
     key: str = Field(..., min_length=1, max_length=100)
-    field_type: FieldType = Field(...)  # single_line_text, number, date, boolean, reference, attachment
+    field_type: FieldType = Field(...)  # single_line_text, number, date, boolean, reference, multi_reference, attachment
     is_required: bool = False
     sort_order: int = 0
     config: dict[str, Any] | None = None  # For reference: {"reference_source_kpi_id": int, "reference_source_field_key": str}

--- a/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
+++ b/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useSearchParams, useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 import { getAccessToken } from "@/lib/auth";
 import { api, getApiUrl } from "@/lib/api";
+import MultiReferenceInput from "@/components/MultiReferenceInput";
 
 interface ReferenceConfig {
   reference_source_kpi_id?: number;
@@ -132,6 +133,9 @@ function expectedPeriods(dimension: string): string[] {
 
 function formatValue(f: FieldDef, v: FieldValueResp | undefined): string {
   if (!v) return "—";
+  if (f.field_type === "multi_reference" && Array.isArray(v.value_json)) {
+    return (v.value_json as string[]).join(", ") || "—";
+  }
   if (v.value_text != null) return String(v.value_text);
   if (v.value_number != null) return String(v.value_number);
   if (v.value_boolean != null) return v.value_boolean ? "Yes" : "No";
@@ -270,7 +274,14 @@ export default function DomainKpiDetailPage() {
   const [columnAccessAddRoleId, setColumnAccessAddRoleId] = useState<number | null>(null);
   const [columnAccessAddPermission, setColumnAccessAddPermission] = useState<"view" | "data_entry">("data_entry");
 
-  type FormCell = { value_text?: string; value_number?: number; value_boolean?: boolean; value_date?: string; value_json?: Record<string, unknown>[] };
+  type FormCell = {
+    value_text?: string;
+    value_number?: number;
+    value_boolean?: boolean;
+    value_date?: string;
+    /** multi_line_items rows or multi_reference string[] */
+    value_json?: Record<string, unknown>[] | string[];
+  };
   const [formValues, setFormValues] = useState<Record<number, FormCell>>({});
 
   const token = getAccessToken();
@@ -765,7 +776,8 @@ export default function DomainKpiDetailPage() {
     if (!token || effectiveOrgId == null || fields.length === 0) return;
     const keys: Array<{ k: string; sid: number; skey: string; subKey?: string }> = [];
     fields.forEach((f) => {
-      if (f.field_type === "reference" && f.config?.reference_source_kpi_id && f.config?.reference_source_field_key) {
+      const refLike = (ft: string) => ft === "reference" || ft === "multi_reference";
+      if (refLike(f.field_type) && f.config?.reference_source_kpi_id && f.config?.reference_source_field_key) {
         keys.push({
           k: `${f.config.reference_source_kpi_id}-${f.config.reference_source_field_key}${f.config.reference_source_sub_field_key ? `-${f.config.reference_source_sub_field_key}` : ""}`,
           sid: f.config.reference_source_kpi_id,
@@ -774,7 +786,7 @@ export default function DomainKpiDetailPage() {
         });
       }
       (f.sub_fields ?? []).forEach((s) => {
-        if (s.field_type === "reference" && s.config?.reference_source_kpi_id && s.config?.reference_source_field_key) {
+        if (refLike(s.field_type) && s.config?.reference_source_kpi_id && s.config?.reference_source_field_key) {
           keys.push({
             k: `${s.config.reference_source_kpi_id}-${s.config.reference_source_field_key}${s.config.reference_source_sub_field_key ? `-${s.config.reference_source_sub_field_key}` : ""}`,
             sid: s.config.reference_source_kpi_id,
@@ -802,6 +814,8 @@ export default function DomainKpiDetailPage() {
       const v = valueMap.get(f.id);
       if (f.field_type === "multi_line_items") {
         out[f.id] = { value_json: Array.isArray(v?.value_json) ? (v!.value_json as Record<string, unknown>[]) : [] };
+      } else if (f.field_type === "multi_reference") {
+        out[f.id] = { value_json: Array.isArray(v?.value_json) ? (v!.value_json as string[]) : [] };
       } else {
         out[f.id] = {};
         if (v?.value_text != null) out[f.id].value_text = v.value_text;
@@ -869,7 +883,11 @@ export default function DomainKpiDetailPage() {
     });
   };
 
-  const updateField = (fieldId: number, key: keyof FormCell, value: string | number | boolean | Record<string, unknown>[] | undefined) => {
+  const updateField = (
+    fieldId: number,
+    key: keyof FormCell,
+    value: string | number | boolean | Record<string, unknown>[] | string[] | undefined
+  ) => {
     setFormValues((prev) => ({ ...prev, [fieldId]: { ...prev[fieldId], [key]: value } }));
   };
 
@@ -882,14 +900,25 @@ export default function DomainKpiDetailPage() {
         .filter((f) => f.field_type !== "formula" && (f.can_edit !== false))
         .map((f) => {
           const v = formValues[f.id] ?? {};
-          const payload: { field_id: number; value_text?: string | null; value_number?: number | null; value_boolean?: boolean | null; value_date?: string | null; value_json?: Record<string, unknown>[] | null } = {
+          const payload: {
+            field_id: number;
+            value_text?: string | null;
+            value_number?: number | null;
+            value_boolean?: boolean | null;
+            value_date?: string | null;
+            value_json?: Record<string, unknown>[] | string[] | null;
+          } = {
             field_id: f.id,
             value_text: v.value_text ?? null,
             value_number: typeof v.value_number === "number" ? v.value_number : null,
             value_boolean: v.value_boolean ?? null,
             value_date: v.value_date || null,
           };
-          if (f.field_type === "multi_line_items" && Array.isArray(v.value_json)) payload.value_json = v.value_json;
+          if (f.field_type === "multi_line_items" && Array.isArray(v.value_json)) payload.value_json = v.value_json as Record<string, unknown>[];
+          if (f.field_type === "multi_reference") {
+            payload.value_text = null;
+            payload.value_json = Array.isArray(v.value_json) ? (v.value_json as string[]) : [];
+          }
           return payload;
         });
       const saveQuery = `?${qs({ organization_id: effectiveOrgId })}`;
@@ -1933,6 +1962,19 @@ export default function DomainKpiDetailPage() {
                               <option key={opt} value={opt}>{opt}</option>
                             ))}
                           </select>
+                        </div>
+                      );
+                    }
+                    if (f.field_type === "multi_reference") {
+                      const refKey = f.config?.reference_source_kpi_id && f.config?.reference_source_field_key
+                        ? `${f.config.reference_source_kpi_id}-${f.config.reference_source_field_key}${f.config.reference_source_sub_field_key ? `-${f.config.reference_source_sub_field_key}` : ""}`
+                        : "";
+                      const options = refAllowedValues[refKey] ?? [];
+                      const arr = Array.isArray(val?.value_json) ? (val!.value_json as string[]) : [];
+                      return (
+                        <div key={f.id} style={{ display: "flex", flexDirection: "column", gap: "0.25rem", maxWidth: 480 }}>
+                          <label style={{ fontWeight: 500 }}>{f.name}{f.is_required ? " *" : ""}</label>
+                          <MultiReferenceInput options={options} value={arr} onChange={(next) => updateField(f.id, "value_json", next)} />
                         </div>
                       );
                     }
@@ -3013,8 +3055,11 @@ export default function DomainKpiDetailPage() {
           if (activeTab !== f.id) return null;
           const v = valuesByFieldId.get(f.id);
           const multiFieldCanEdit = (f as FieldDef).can_edit !== false;
-          const formRows = isEditing && multiFieldCanEdit ? (formValues[f.id]?.value_json ?? []) : [];
-          const rows = !multiFieldCanEdit
+          const formRows: Record<string, unknown>[] =
+            isEditing && multiFieldCanEdit && Array.isArray(formValues[f.id]?.value_json)
+              ? (formValues[f.id]!.value_json as Record<string, unknown>[])
+              : [];
+          const rows: Record<string, unknown>[] = !multiFieldCanEdit
             ? (Array.isArray(v?.value_json) ? (v!.value_json as Record<string, unknown>[]) : [])
             : (isEditing ? formRows : (Array.isArray(v?.value_json) ? (v!.value_json as Record<string, unknown>[]) : []));
           const subFields = f.sub_fields ?? [];
@@ -3044,7 +3089,13 @@ export default function DomainKpiDetailPage() {
                           type="button"
                           className="btn"
                           disabled={isLocked}
-                          onClick={() => setRows([...rows, Object.fromEntries(subFields.map((s) => [s.key, undefined]))])}
+                          onClick={() => {
+                            const empty: Record<string, unknown> = {};
+                            for (const s of subFields) {
+                              empty[s.key] = s.field_type === "multi_reference" ? [] : undefined;
+                            }
+                            setRows([...rows, empty]);
+                          }}
                         >
                           Add row
                         </button>
@@ -3698,6 +3749,28 @@ export default function DomainKpiDetailPage() {
                                             <option key={opt} value={opt}>{opt}</option>
                                           ))}
                                         </select>
+                                      );
+                                    })()
+                                  ) : s.field_type === "multi_reference" ? (
+                                    (() => {
+                                      const refKey = s.config?.reference_source_kpi_id && s.config?.reference_source_field_key
+                                        ? `${s.config.reference_source_kpi_id}-${s.config.reference_source_field_key}${s.config.reference_source_sub_field_key ? `-${s.config.reference_source_sub_field_key}` : ""}`
+                                        : "";
+                                      const options = refAllowedValues[refKey] ?? [];
+                                      const cellVal = row[s.key];
+                                      const arr = Array.isArray(cellVal) ? (cellVal as string[]) : [];
+                                      return (
+                                        <div style={{ minWidth: 140, maxWidth: 320 }}>
+                                          <MultiReferenceInput
+                                            options={options}
+                                            value={arr}
+                                            onChange={(next) => {
+                                              const nextRows = [...rows];
+                                              nextRows[rowIdx] = { ...nextRows[rowIdx], [s.key]: next };
+                                              setRows(nextRows);
+                                            }}
+                                          />
+                                        </div>
                                       );
                                     })()
                                   ) : s.field_type === "attachment" ? (

--- a/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
+++ b/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
@@ -1290,6 +1290,13 @@ export default function FullPageMultiItems() {
                     >
                       {(() => {
                         const cellVal = row.data[sf.key];
+                        if (sf.field_type === "multi_reference") {
+                          const arr = Array.isArray(cellVal)
+                            ? (cellVal as unknown[]).filter((x) => x != null && String(x).trim() !== "")
+                            : [];
+                          if (arr.length === 0) return "—";
+                          return arr.map((x) => String(x)).join("; ");
+                        }
                         if (cellVal == null || String(cellVal).trim() === "") return "—";
                         const strVal = String(cellVal);
                         if (sf.field_type === "attachment") {

--- a/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/row/[rowIndex]/page.tsx
+++ b/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/row/[rowIndex]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { getAccessToken } from "@/lib/auth";
 import { api, getApiUrl } from "@/lib/api";
 import { toast } from "react-toastify";
+import MultiReferenceInput from "@/components/MultiReferenceInput";
 
 type SubField = {
   key: string;
@@ -197,13 +198,13 @@ export default function MultiItemRowDetail() {
     setActiveSectionTab((prev) => (prev && labels.includes(prev) ? prev : labels[0] || ""));
   }, [hasSectionTabs, sectionGroups]);
 
-  // Load reference allowed values for reference sub-fields (same logic as inline editor)
+  // Load reference allowed values for reference / multi_reference sub-fields (same logic as inline editor)
   useEffect(() => {
     if (!token || effectiveOrgId == null || !field || !field.sub_fields?.length) return;
     const keys: { k: string; sid: number; skey: string; subKey?: string }[] = [];
     field.sub_fields.forEach((s) => {
       if (
-        s.field_type === "reference" &&
+        (s.field_type === "reference" || s.field_type === "multi_reference") &&
         (s as any).config?.reference_source_kpi_id &&
         (s as any).config?.reference_source_field_key
       ) {
@@ -407,6 +408,9 @@ export default function MultiItemRowDetail() {
                         : val != null
                         ? String(val)
                         : "—";
+                  } else if (sf.field_type === "multi_reference") {
+                    const arr = Array.isArray(val) ? (val as unknown[]).filter((x) => x != null && String(x).trim() !== "") : [];
+                    display = arr.length > 0 ? arr.map((x) => String(x)).join("; ") : "—";
                   } else {
                     display = val != null && String(val).trim() !== "" ? String(val) : "—";
                   }
@@ -519,6 +523,11 @@ export default function MultiItemRowDetail() {
                     ? Boolean(val) ? "Yes" : "No"
                     : sf.field_type === "date"
                       ? (typeof val === "string" && val ? val : "—")
+                      : sf.field_type === "multi_reference"
+                        ? (() => {
+                            const arr = Array.isArray(val) ? (val as unknown[]).filter((x) => x != null && String(x).trim() !== "") : [];
+                            return arr.length > 0 ? arr.map((x) => String(x)).join("; ") : "—";
+                          })()
                       : val != null && String(val).trim() !== "" ? String(val) : "—";
                 if (!canEdit) {
                   return (
@@ -612,6 +621,36 @@ export default function MultiItemRowDetail() {
                           </option>
                         ))}
                       </select>
+                    </div>
+                  );
+                }
+                if (sf.field_type === "multi_reference") {
+                  const cfg = (sf as any).config as
+                    | {
+                        reference_source_kpi_id?: number;
+                        reference_source_field_key?: string;
+                        reference_source_sub_field_key?: string;
+                      }
+                    | undefined;
+                  const refKey =
+                    cfg?.reference_source_kpi_id && cfg?.reference_source_field_key
+                      ? `${cfg.reference_source_kpi_id}-${cfg.reference_source_field_key}${
+                          cfg.reference_source_sub_field_key ? `-${cfg.reference_source_sub_field_key}` : ""
+                        }`
+                      : "";
+                  const options = refAllowedValues[refKey] ?? [];
+                  const arr = Array.isArray(val) ? (val as string[]) : [];
+                  return (
+                    <div key={key} className="form-group">
+                      <label>
+                        {sf.name}
+                        {sf.is_required ? " *" : ""}
+                      </label>
+                      <MultiReferenceInput
+                        options={options}
+                        value={arr}
+                        onChange={(next) => handleChangeCell(key, next)}
+                      />
                     </div>
                   );
                 }

--- a/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
+++ b/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
@@ -26,11 +26,12 @@ const FIELD_TYPES = [
   "boolean",
   "attachment",
   "reference",
+  "multi_reference",
   "multi_line_items",
   "formula",
 ] as const;
 
-const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "attachment"] as const;
+const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference", "attachment"] as const;
 
 function slugifyKey(name: string): string {
   if (!name) return "";
@@ -412,7 +413,11 @@ export default function KpiFieldsPage() {
         full_page_multi_items: data.full_page_multi_items ?? false,
         options: [],
       };
-      if (data.field_type === "reference" && createRefConfig.reference_source_kpi_id && createRefConfig.reference_source_field_key) {
+      if (
+        (data.field_type === "reference" || data.field_type === "multi_reference") &&
+        createRefConfig.reference_source_kpi_id &&
+        createRefConfig.reference_source_field_key
+      ) {
         body.config = {
           reference_source_kpi_id: createRefConfig.reference_source_kpi_id,
           reference_source_field_key: createRefConfig.reference_source_field_key,
@@ -434,7 +439,7 @@ export default function KpiFieldsPage() {
               : "";
           const hasUiSection = uiSection.length > 0;
           const hasRefConfig =
-            s.field_type === "reference" &&
+            (s.field_type === "reference" || s.field_type === "multi_reference") &&
             s.config?.reference_source_kpi_id &&
             s.config?.reference_source_field_key;
 
@@ -502,7 +507,11 @@ export default function KpiFieldsPage() {
         carry_forward_data: data.carry_forward_data,
         full_page_multi_items: data.full_page_multi_items,
       };
-      if (data.field_type === "reference" && refConfig?.reference_source_kpi_id && refConfig?.reference_source_field_key) {
+      if (
+        (data.field_type === "reference" || data.field_type === "multi_reference") &&
+        refConfig?.reference_source_kpi_id &&
+        refConfig?.reference_source_field_key
+      ) {
         body.config = {
           reference_source_kpi_id: refConfig.reference_source_kpi_id,
           reference_source_field_key: refConfig.reference_source_field_key,
@@ -537,7 +546,7 @@ export default function KpiFieldsPage() {
               : "";
           const hasUiSection = uiSection.length > 0;
           const hasRefConfig =
-            s.field_type === "reference" &&
+            (s.field_type === "reference" || s.field_type === "multi_reference") &&
             s.config?.reference_source_kpi_id &&
             s.config?.reference_source_field_key;
 
@@ -1441,11 +1450,13 @@ export default function KpiFieldsPage() {
                 <input type="number" min={0} {...createForm.register("sort_order")} style={{ width: "4.5rem", padding: "0.35rem 0.5rem" }} />
               </div>
             </div>
-            {createForm.watch("field_type") === "reference" && (
+            {(createForm.watch("field_type") === "reference" || createForm.watch("field_type") === "multi_reference") && (
               <div className="form-group">
                 <label>Reference source</label>
                 <p style={{ color: "var(--muted)", fontSize: "0.85rem", margin: "0.25rem 0 0.5rem 0" }}>
-                  Values for this field will be restricted to distinct values from the selected KPI field.
+                  {createForm.watch("field_type") === "multi_reference"
+                    ? "Users may pick multiple values; each must appear in the distinct values from the selected KPI field."
+                    : "Values for this field will be restricted to distinct values from the selected KPI field."}
                 </p>
                 <ReferenceConfigUI
                   organizationId={kpi?.organization_id ?? orgId ?? undefined}
@@ -1481,7 +1492,7 @@ export default function KpiFieldsPage() {
                         <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Name</th>
                         <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Key</th>
                         <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Type</th>
-                        <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Reference source (if type = reference)</th>
+                        <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Reference source (reference / multi reference)</th>
                         <th style={{ textAlign: "center", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Required</th>
                         <th style={{ width: "80px", padding: "0.5rem", borderBottom: "2px solid var(--border)" }} />
                       </tr>
@@ -1536,7 +1547,7 @@ export default function KpiFieldsPage() {
                             </select>
                           </td>
                           <td style={{ padding: "0.4rem 0.5rem", minWidth: "200px" }}>
-                            {s.field_type === "reference" ? (
+                            {s.field_type === "reference" || s.field_type === "multi_reference" ? (
                               <ReferenceConfigUI
                                 organizationId={kpi?.organization_id ?? orgId ?? undefined}
                                 currentKpiId={kpiId}
@@ -1923,7 +1934,7 @@ function ReferenceConfigUI({
       .then((list) => setSourceFields(list))
       .catch(() => setSourceFields([]));
   }, [token, organizationId, value.reference_source_kpi_id]);
-  const scalarFieldTypes = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference"];
+  const scalarFieldTypes = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference"];
   const sourceFieldOptions: { value: string; label: string }[] = [];
   sourceFields.forEach((f) => {
     if (scalarFieldTypes.includes(f.field_type)) {
@@ -2042,7 +2053,7 @@ function FormulaBuilder({
   const canInsertOtherKpiField = refOtherKpiId !== "" && refOtherFieldKey !== "";
   const getRefSourceFromSubKey = (subKey: string): { cacheKey: string; sid: number; skey: string; sourceSubKey?: string } | null => {
     const sf = subFields.find((s) => s.key === subKey);
-    if (!sf || sf.field_type !== "reference") return null;
+    if (!sf || (sf.field_type !== "reference" && sf.field_type !== "multi_reference")) return null;
     const cfg = (sf.config ?? {}) as ReferenceConfig;
     const sid = cfg.reference_source_kpi_id;
     const skey = cfg.reference_source_field_key;
@@ -2367,7 +2378,7 @@ function FieldEditForm({
           currentFieldType === "multi_line_items"
             ? editSubFields.map(({ keyTouched: _, ...s }) => s)
             : undefined,
-          currentFieldType === "reference" ? editRefConfig : undefined
+          currentFieldType === "reference" || currentFieldType === "multi_reference" ? editRefConfig : undefined
         )
       )}
       style={{ width: "100%" }}
@@ -2489,11 +2500,13 @@ function FieldEditForm({
           />
         </div>
       </div>
-      {currentFieldType === "reference" && (
+      {(currentFieldType === "reference" || currentFieldType === "multi_reference") && (
         <div className="form-group">
           <label>Reference source</label>
           <p style={{ color: "var(--muted)", fontSize: "0.85rem", margin: "0.25rem 0 0.5rem 0" }}>
-            Values for this field will be restricted to distinct values from the selected KPI field.
+            {currentFieldType === "multi_reference"
+              ? "Users may pick multiple values; each must appear in the distinct values from the selected KPI field."
+              : "Values for this field will be restricted to distinct values from the selected KPI field."}
           </p>
           <ReferenceConfigUI
             organizationId={organizationId}
@@ -2529,7 +2542,7 @@ function FieldEditForm({
                   <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Name</th>
                   <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Key</th>
                   <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Type</th>
-                  <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Reference source (if type = reference)</th>
+                  <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Reference source (reference / multi reference)</th>
                   <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Section (UI)</th>
                   <th style={{ textAlign: "center", padding: "0.5rem", borderBottom: "2px solid var(--border)", fontWeight: 600 }}>Required</th>
                   <th style={{ width: "80px", padding: "0.5rem", borderBottom: "2px solid var(--border)" }} />
@@ -2583,7 +2596,7 @@ function FieldEditForm({
                       </select>
                     </td>
                     <td style={{ padding: "0.4rem 0.5rem", minWidth: "200px" }}>
-                      {s.field_type === "reference" ? (
+                      {s.field_type === "reference" || s.field_type === "multi_reference" ? (
                         <ReferenceConfigUI
                           organizationId={organizationId}
                           currentKpiId={currentKpiId}

--- a/frontend/src/app/dashboard/organizations/[id]/page.tsx
+++ b/frontend/src/app/dashboard/organizations/[id]/page.tsx
@@ -28,7 +28,7 @@ const FIELD_TYPES = [
   "formula",
 ] as const;
 
-const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "attachment"] as const;
+const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference", "attachment"] as const;
 
 const GROUP_FUNCTIONS = [
   { value: "SUM_ITEMS", label: "SUM (total)" },

--- a/frontend/src/components/MultiReferenceInput.tsx
+++ b/frontend/src/components/MultiReferenceInput.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import React, { useId, useMemo, useState } from "react";
+
+type Props = {
+  options: string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+};
+
+/** Multi-select from allowed reference values (same source KPI/field as single reference). */
+export default function MultiReferenceInput({ options, value, onChange, disabled, placeholder }: Props) {
+  const id = useId();
+  const listId = `${id}-mr-list`;
+  const [draft, setDraft] = useState("");
+
+  const uniqOptions = useMemo(() => Array.from(new Set(options.filter(Boolean))), [options]);
+
+  const addToken = (raw: string) => {
+    const t = raw.trim();
+    if (!t) return;
+    if (!value.includes(t)) onChange([...value, t]);
+    setDraft("");
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", minWidth: 0 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.3rem", alignItems: "center" }}>
+        {value.map((v) => (
+          <span
+            key={v}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.25rem",
+              padding: "0.15rem 0.45rem",
+              borderRadius: 12,
+              background: "var(--bg-subtle, #f3f4f6)",
+              fontSize: "0.8rem",
+              maxWidth: "100%",
+            }}
+          >
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{v}</span>
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${v}`}
+                onClick={() => onChange(value.filter((x) => x !== v))}
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  cursor: "pointer",
+                  padding: 0,
+                  lineHeight: 1,
+                  color: "var(--danger, #b91c1c)",
+                }}
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+      </div>
+      {!disabled && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "0.35rem", alignItems: "center" }}>
+          <input
+            type="text"
+            list={listId}
+            value={draft}
+            placeholder={placeholder ?? "Type to filter, then pick or press Enter"}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const pick = draft.trim();
+                if (pick && uniqOptions.includes(pick)) addToken(pick);
+              }
+            }}
+            style={{
+              flex: "1 1 160px",
+              minWidth: 120,
+              padding: "0.35rem 0.5rem",
+              borderRadius: 6,
+              border: "1px solid var(--border)",
+              fontSize: "0.85rem",
+            }}
+          />
+          <datalist id={listId}>
+            {uniqOptions.map((o) => (
+              <option key={o} value={o} />
+            ))}
+          </datalist>
+          <button
+            type="button"
+            className="btn"
+            style={{ padding: "0.3rem 0.55rem", fontSize: "0.8rem" }}
+            disabled={!draft.trim() || !uniqOptions.includes(draft.trim())}
+            onClick={() => addToken(draft)}
+          >
+            Add
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduced a new migration to add 'multi_reference' as a value in the fieldtype enum, enhancing the flexibility of field types.
- Updated the backend to handle multi-reference fields, including validation and filtering of allowed values.
- Enhanced frontend components to support multi-reference input, allowing users to select multiple values from a defined list.
- Updated relevant schemas and service functions to accommodate the new multi-reference type, ensuring consistency across the application.