### PR TITLE
Add mixed_list field type and related functionality

### DIFF
--- a/backend/alembic/versions/032_fieldtype_mixed_list.py
+++ b/backend/alembic/versions/032_fieldtype_mixed_list.py
@@ -1,0 +1,27 @@
+"""Add mixed_list value to fieldtype enum.
+
+Revision ID: 032_fieldtype_mixed_list
+Revises: 031_dashboards
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "032_fieldtype_mixed_list"
+down_revision: Union[str, None] = "031_dashboards"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    try:
+        op.execute("ALTER TYPE fieldtype ADD VALUE 'mixed_list'")
+    except Exception:
+        pass
+
+
+def downgrade() -> None:
+    pass
+

--- a/backend/app/core/models.py
+++ b/backend/app/core/models.py
@@ -42,6 +42,7 @@ class FieldType(str, enum.Enum):
     date = "date"
     boolean = "boolean"
     attachment = "attachment"  # URL to an attachment (this KPI or other KPIs)
+    mixed_list = "mixed_list"  # JSON list that may contain strings, numbers, and ISO date strings
     multi_line_items = "multi_line_items"
     formula = "formula"
     reference = "reference"  # Reference/Lookup: values from another KPI field

--- a/backend/app/entries/routes.py
+++ b/backend/app/entries/routes.py
@@ -55,6 +55,7 @@ from app.entries.service import (
     _upsert_merge_multi_line_items,
     _is_multi_items_row_effectively_empty,
     parse_upsert_match_keys_json,
+    coerce_mixed_list_raw,
 )
 from app.fields.service import list_fields as list_kpi_fields_service
 from app.kpis.service import sync_kpi_entry_from_api
@@ -172,6 +173,11 @@ def _serialize_multi_item_cell_for_xlsx(val: Any, field_type: FieldType | str | 
             parts = [str(x).strip() for x in val if x is not None and str(x).strip() != ""]
             return "; ".join(parts)
         return str(val).strip() if str(val).strip() else ""
+    if ft == FieldType.mixed_list.value or ft == "mixed_list":
+        if isinstance(val, list):
+            parts = [str(x).strip() for x in val if x is not None and str(x).strip() != ""]
+            return "; ".join(parts)
+        return str(val).strip() if val is not None and str(val).strip() else ""
     if isinstance(val, list):
         parts = [str(x).strip() for x in val if x is not None and str(x).strip() != ""]
         return "; ".join(parts)
@@ -185,6 +191,10 @@ def _serialize_multi_item_cell_for_csv(val: Any, field_type: FieldType | str | N
         return ""
     ft = field_type.value if isinstance(field_type, FieldType) else field_type
     if ft == FieldType.multi_reference.value or ft == "multi_reference":
+        if isinstance(val, list):
+            return "; ".join(str(x).strip() for x in val if x is not None and str(x).strip() != "")
+        return val
+    if ft == FieldType.mixed_list.value or ft == "mixed_list":
         if isinstance(val, list):
             return "; ".join(str(x).strip() for x in val if x is not None and str(x).strip() != "")
         return val
@@ -297,6 +307,9 @@ def _parse_multi_items_xlsx(content: bytes, field: KPIField) -> list[dict]:
             elif sf.field_type == FieldType.multi_reference:
                 # Semicolon (or comma) separated in Excel; validated on upload.
                 item[key] = str(raw).strip() if raw is not None else ""
+            elif sf.field_type == FieldType.mixed_list:
+                # Semicolon separated values in Excel; infer number/date/string.
+                item[key] = coerce_mixed_list_raw(str(raw) if raw is not None else "") or None
             else:
                 # Text / reference / attachment: Excel often stores numeric ids as float (e.g. 42.0).
                 if isinstance(raw, (int, float)) and not isinstance(raw, bool):
@@ -816,12 +829,21 @@ async def add_multi_items_row(
         db.add(fv)
     if not isinstance(fv.value_json, list):
         fv.value_json = []
-    fv.value_json.append(row)
+    # Normalize special sub-field types (e.g. mixed_list) for consistent storage.
+    normalized_row = row if isinstance(row, dict) else {}
+    key_to_sub = {getattr(s, "key", None): s for s in (field.sub_fields or []) if getattr(s, "key", None)}
+    for k, v in list(normalized_row.items()):
+        sub = key_to_sub.get(k)
+        if not sub:
+            continue
+        if getattr(sub, "field_type", None) == FieldType.mixed_list:
+            normalized_row[k] = coerce_mixed_list_raw(v) or None
+    fv.value_json.append(normalized_row)
     flag_modified(fv, "value_json")
     await db.flush()
     await db.commit()
     index = len(fv.value_json) - 1
-    return MultiItemsRow(index=index, data=row)
+    return MultiItemsRow(index=index, data=normalized_row)
 
 
 @router.put("/multi-items/rows/{row_index}", response_model=MultiItemsRow)
@@ -867,7 +889,10 @@ async def update_multi_items_row(
         if sub is None:
             continue
         if await user_can_edit_field(db, current_user.id, entry.kpi_id, field.id, getattr(sub, "id", None)):
-            existing_row[col_key] = col_value
+            if getattr(sub, "field_type", None) == FieldType.mixed_list:
+                existing_row[col_key] = coerce_mixed_list_raw(col_value) or None
+            else:
+                existing_row[col_key] = col_value
     fv.value_json[row_index] = existing_row
     flag_modified(fv, "value_json")
     await db.flush()
@@ -926,7 +951,10 @@ async def update_multi_items_row_cell(
         row = {}
         fv.value_json[row_index] = row
 
-    row[key] = value
+    if getattr(sub, "field_type", None) == FieldType.mixed_list:
+        row[key] = coerce_mixed_list_raw(value) or None
+    else:
+        row[key] = value
     flag_modified(fv, "value_json")  # SQLAlchemy does not track in-place JSON mutations
     await db.flush()
     await db.commit()
@@ -1552,6 +1580,7 @@ def _build_kpi_entry_xlsx(
         FieldType.formula,
         FieldType.reference,
         FieldType.multi_reference,
+        FieldType.mixed_list,
     )
     scalar_fields = [f for f in fields if getattr(f, "field_type", None) in scalar_types]
     ws_scalar = wb.active
@@ -1564,6 +1593,8 @@ def _build_kpi_entry_xlsx(
             continue
         ft = getattr(f, "field_type", None)
         if ft == FieldType.multi_reference and isinstance(fv.value_json, list):
+            val = "; ".join(str(x) for x in fv.value_json)
+        elif ft == FieldType.mixed_list and isinstance(fv.value_json, list):
             val = "; ".join(str(x) for x in fv.value_json)
         elif fv.value_text is not None:
             val = fv.value_text
@@ -1603,6 +1634,8 @@ def _build_kpi_entry_xlsx(
                 raw = row.get(col_key, "")
                 sf = key_to_sf.get(col_key)
                 if sf and getattr(sf, "field_type", None) == FieldType.multi_reference and isinstance(raw, list):
+                    return "; ".join(str(x) for x in raw)
+                if sf and getattr(sf, "field_type", None) == FieldType.mixed_list and isinstance(raw, list):
                     return "; ".join(str(x) for x in raw)
                 return raw if raw is not None else ""
 
@@ -1730,6 +1763,9 @@ def _parse_kpi_entry_xlsx(
             elif ft == FieldType.multi_reference:
                 parsed = coerce_multi_reference_raw(str(raw_value) if raw_value is not None else "")
                 val["value_json"] = parsed if parsed else None
+            elif ft == FieldType.mixed_list:
+                parsed = coerce_mixed_list_raw(str(raw_value) if raw_value is not None else "")
+                val["value_json"] = parsed if parsed else None
             else:
                 val["value_text"] = str(raw_value) if raw_value is not None else None
             result[field.id] = val
@@ -1802,6 +1838,9 @@ def _parse_kpi_entry_xlsx(
                         item[key] = str(raw)
                 elif sf_type == FieldType.multi_reference or sf_type == "multi_reference":
                     parsed = coerce_multi_reference_raw(str(raw) if raw is not None else "")
+                    item[key] = parsed if parsed else None
+                elif sf_type == FieldType.mixed_list or sf_type == "mixed_list":
+                    parsed = coerce_mixed_list_raw(str(raw) if raw is not None else "")
                     item[key] = parsed if parsed else None
                 else:
                     item[key] = str(raw)

--- a/backend/app/entries/service.py
+++ b/backend/app/entries/service.py
@@ -189,6 +189,84 @@ def coerce_multi_reference_raw(raw: Any) -> list[Any]:
     return [raw]
 
 
+_ISO_DATE_RE = __import__("re").compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _infer_mixed_list_atom(val: Any) -> Any | None:
+    """Infer a JSON-storable atom for mixed_list: number, ISO date string, or string. Returns None for empty."""
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        # Keep booleans as strings to avoid ambiguity in UI and Excel ("true"/"false" tokens are common labels).
+        return "true" if val else "false"
+    if isinstance(val, (int, float)) and not isinstance(val, bool):
+        if isinstance(val, float):
+            if math.isfinite(val) and val == int(val):
+                return int(val)
+            return float(val)
+        return int(val)
+    if isinstance(val, str):
+        s = val.strip()
+        if not s:
+            return None
+        # ISO date detection (as typed date)
+        if _ISO_DATE_RE.match(s):
+            return s
+        # Numeric detection (accept thousands separators)
+        try:
+            num = float(s.replace(",", ""))
+            if math.isfinite(num) and num == int(num):
+                return int(num)
+            if math.isfinite(num):
+                return num
+        except ValueError:
+            pass
+        return s
+    # Fallback: stringify unknown objects
+    s = str(val).strip()
+    return s or None
+
+
+def coerce_mixed_list_raw(raw: Any) -> list[Any]:
+    """
+    Normalize input into a heterogeneous JSON list of atoms:
+    - Accept list inputs directly.
+    - Accept strings with ';' separated tokens (primary) and ',' as fallback.
+    - Infer numbers and ISO dates (YYYY-MM-DD) per token; otherwise keep as string.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        out: list[Any] = []
+        for x in raw:
+            atom = _infer_mixed_list_atom(x)
+            if atom is not None:
+                out.append(atom)
+        return out
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return []
+        # JSON list payload in string form
+        if s.startswith("["):
+            try:
+                parsed = json.loads(s)
+                if isinstance(parsed, list):
+                    return coerce_mixed_list_raw(parsed)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        parts = [p.strip() for p in (s.split(";") if ";" in s else s.split(",")) if p.strip()]
+        out: list[Any] = []
+        for p in parts:
+            atom = _infer_mixed_list_atom(p)
+            if atom is not None:
+                out.append(atom)
+        return out
+    # Single scalar: wrap
+    atom = _infer_mixed_list_atom(raw)
+    return [atom] if atom is not None else []
+
+
 def _canonical_by_normalized_reference(allowed: list[str]) -> dict[str, str]:
     """Map normalized token -> first canonical display string from allowed list."""
     out: dict[str, str] = {}
@@ -1004,6 +1082,13 @@ async def save_entry_values(
         f = next((x for x in kpi.fields if x.id == v.field_id), None)
         if not f:
             continue
+        if f.field_type == FieldType.mixed_list:
+            # Accept value_text (semicolon separated), value_json (list), or raw scalars; store in value_json only.
+            raw_in = v.value_json if v.value_json is not None else v.value_text
+            coerced = coerce_mixed_list_raw(raw_in)
+            v.value_text = None
+            v.value_json = coerced if coerced else None
+            continue
         if f.field_type == FieldType.reference:
             config = getattr(f, "config", None) or {}
             sid = config.get("reference_source_kpi_id")
@@ -1045,6 +1130,12 @@ async def save_entry_values(
                 skey = config.get("reference_source_field_key")
                 sub_key = config.get("reference_source_sub_field_key")
                 if not sid or not skey:
+                    # Still allow normalization for non-reference types.
+                    if ft == FieldType.mixed_list:
+                        for row in v.value_json:
+                            if not isinstance(row, dict):
+                                continue
+                            row[sub.key] = coerce_mixed_list_raw(row.get(sub.key)) or None
                     continue
                 if ft == FieldType.reference:
                     allowed = await get_reference_allowed_values(db, int(sid), str(skey), org_id, source_sub_field_key=sub_key)
@@ -1071,6 +1162,11 @@ async def save_entry_values(
                         cell = row.get(sub.key)
                         cleaned = filter_multi_reference_to_allowed(cell, allowed)
                         row[sub.key] = cleaned if cleaned else None
+                elif ft == FieldType.mixed_list:
+                    for row in v.value_json:
+                        if not isinstance(row, dict):
+                            continue
+                        row[sub.key] = coerce_mixed_list_raw(row.get(sub.key)) or None
 
     if validation_errors:
         raise EntryValidationError(validation_errors)

--- a/backend/app/fields/schemas.py
+++ b/backend/app/fields/schemas.py
@@ -15,6 +15,7 @@ SUB_FIELD_TYPES = (
     FieldType.reference,
     FieldType.multi_reference,
     FieldType.attachment,
+    FieldType.mixed_list,
 )
 
 
@@ -23,7 +24,7 @@ class KPIFieldSubFieldCreate(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=255)
     key: str = Field(..., min_length=1, max_length=100)
-    field_type: FieldType = Field(...)  # single_line_text, number, date, boolean, reference, multi_reference, attachment
+    field_type: FieldType = Field(...)  # single_line_text, number, date, boolean, reference, multi_reference, attachment, mixed_list
     is_required: bool = False
     sort_order: int = 0
     config: dict[str, Any] | None = None  # For reference: {"reference_source_kpi_id": int, "reference_source_field_key": str}

--- a/backend/app/kpis/routes.py
+++ b/backend/app/kpis/routes.py
@@ -736,23 +736,42 @@ def _example_value_for_field(f) -> str | int | float | bool | list[dict] | None:
         return 1  # API may send 1 or 0
     if ft == "date":
         return "2025-01-15"
+    if ft == "mixed_list":
+        return ["Sample text", 123, "2026-04-01"]
     if ft == "multi_line_items":
         sub_fields = getattr(f, "sub_fields", None) or []
         sub_keys = [getattr(s, "key", f"col_{i}") for i, s in enumerate(sub_fields)]
         if not sub_keys:
             sub_keys = ["item_name", "quantity"]
         # Example: list of row objects; each row has all sub_keys with sample values
-        numeric_types = {"number"}
-        sub_types = {}
+        sub_types: dict[str, str] = {}
         for s in sub_fields:
-            st = getattr(getattr(s, "field_type", None), "value", None) or str(getattr(s, "field_type", "single_line_text"))
-            sub_types[getattr(s, "key", "")] = st in numeric_types
+            st = (
+                getattr(getattr(s, "field_type", None), "value", None)
+                or str(getattr(s, "field_type", "single_line_text"))
+            )
+            sub_types[getattr(s, "key", "")] = (st or "single_line_text").lower()
         rows = []
         for row_idx in range(2):
             row = {}
             for k in sub_keys:
-                if sub_types.get(k, False):
+                st = sub_types.get(k, "single_line_text")
+                if st == "number":
                     row[k] = 85 + row_idx * 5
+                elif st == "boolean":
+                    row[k] = row_idx == 0
+                elif st == "date":
+                    row[k] = "2026-01-15" if row_idx == 0 else "2026-06-30"
+                elif st == "reference":
+                    row[k] = "example_ref_token_alpha" if row_idx == 0 else "example_ref_token_beta"
+                elif st == "multi_reference":
+                    row[k] = ["Alpha", "Beta"] if row_idx == 0 else ["Gamma"]
+                elif st == "mixed_list":
+                    row[k] = ["Sample text", 123, "2026-04-01"] if row_idx == 0 else ["Other", 456, "2026-05-10"]
+                elif st == "attachment":
+                    row[k] = None
+                elif st == "multi_line_text":
+                    row[k] = "First paragraph.\n\nSecond line." if row_idx == 0 else "Another block\nof text."
                 else:
                     row[k] = ("Alice", "Bob")[row_idx]
             rows.append(row)
@@ -784,6 +803,8 @@ async def get_kpi_api_contract(
                 sub_keys.append(getattr(s, "key", ""))
         ex = _example_value_for_field(f)  # None for formula
         accepted_hint = "true, false, 1, or 0" if ft_str == "boolean" else None
+        if ft_str == "mixed_list":
+            accepted_hint = "Send a JSON array (preferred) or a ';' separated string; items may be text, numbers, or ISO dates (YYYY-MM-DD)."
         contract_fields.append(
             KPIApiContractField(
                 key=f.key,

--- a/backend/app/kpis/schemas.py
+++ b/backend/app/kpis/schemas.py
@@ -218,7 +218,10 @@ class KPIApiContractField(BaseModel):
 
     key: str = Field(..., description="Field key – use this in response values")
     name: str = Field(..., description="Display name of the field")
-    field_type: str = Field(..., description="single_line_text, multi_line_text, number, date, boolean, multi_line_items (formula omitted)")
+    field_type: str = Field(
+        ...,
+        description="single_line_text, multi_line_text, number, date, boolean, reference, multi_reference, mixed_list, multi_line_items (formula omitted)",
+    )
     sub_field_keys: list[str] = Field(default_factory=list, description="For multi_line_items: keys for each row object")
     example_value: str | int | float | bool | list[dict] | None = Field(
         None, description="Concrete example to return in response values"

--- a/backend/app/kpis/service.py
+++ b/backend/app/kpis/service.py
@@ -40,6 +40,7 @@ from app.entries.service import (
     save_entry_values,
     _upsert_merge_multi_line_items,
     _is_multi_items_row_effectively_empty,
+    coerce_mixed_list_raw,
 )
 from app.entries.schemas import FieldValueInput
 
@@ -1497,8 +1498,13 @@ async def sync_kpi_entry_from_api(
                 value_inputs.append(FieldValueInput(field_id=f.id, value_json=incoming))
                 _log("    -> ADD value_json len=%s (override)", len(incoming))
         else:
-            value_inputs.append(FieldValueInput(field_id=f.id, value_text=str(raw) if raw is not None else None))
-            _log("    -> ADD value_text=%s", (str(raw)[:80] if raw is not None else None))
+            if ft_norm == "mixed_list":
+                coerced = coerce_mixed_list_raw(raw)
+                value_inputs.append(FieldValueInput(field_id=f.id, value_json=coerced if coerced else None))
+                _log("    -> ADD value_json(mixed_list) len=%s", len(coerced))
+            else:
+                value_inputs.append(FieldValueInput(field_id=f.id, value_text=str(raw) if raw is not None else None))
+                _log("    -> ADD value_text=%s", (str(raw)[:80] if raw is not None else None))
 
     _log("value_inputs count=%s (will save=%s)", len(value_inputs), bool(value_inputs))
     if value_inputs:

--- a/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
+++ b/frontend/src/app/dashboard/domains/[id]/kpis/[kpiId]/page.tsx
@@ -145,6 +145,9 @@ function formatValue(f: FieldDef, v: FieldValueResp | undefined): string {
   if (f.field_type === "multi_reference" && Array.isArray(v.value_json)) {
     return (v.value_json as string[]).join(", ") || "—";
   }
+  if (f.field_type === "mixed_list" && Array.isArray(v.value_json)) {
+    return (v.value_json as (string | number)[]).map((x) => String(x)).join(", ") || "—";
+  }
   if (f.field_type === "attachment" && v.value_text != null) {
     const p = parseScalarAttachmentValueText(v.value_text);
     if (p.url) return p.filename?.trim() || "Attached file";
@@ -299,7 +302,7 @@ export default function DomainKpiDetailPage() {
     value_boolean?: boolean;
     value_date?: string;
     /** multi_line_items rows or multi_reference string[] */
-    value_json?: Record<string, unknown>[] | string[];
+    value_json?: Record<string, unknown>[] | (string | number)[];
   };
   const [formValues, setFormValues] = useState<Record<number, FormCell>>({});
 
@@ -887,6 +890,8 @@ export default function DomainKpiDetailPage() {
         out[f.id] = { value_json: Array.isArray(v?.value_json) ? (v!.value_json as Record<string, unknown>[]) : [] };
       } else if (f.field_type === "multi_reference") {
         out[f.id] = { value_json: Array.isArray(v?.value_json) ? (v!.value_json as string[]) : [] };
+      } else if (f.field_type === "mixed_list") {
+        out[f.id] = { value_json: Array.isArray(v?.value_json) ? (v!.value_json as (string | number)[]) : [] };
       } else {
         out[f.id] = {};
         if (v?.value_text != null) {
@@ -989,7 +994,7 @@ export default function DomainKpiDetailPage() {
             value_number?: number | null;
             value_boolean?: boolean | null;
             value_date?: string | null;
-            value_json?: Record<string, unknown>[] | string[] | null;
+            value_json?: Record<string, unknown>[] | (string | number)[] | null;
           } = {
             field_id: f.id,
             value_text: v.value_text ?? null,
@@ -1001,6 +1006,10 @@ export default function DomainKpiDetailPage() {
           if (f.field_type === "multi_reference") {
             payload.value_text = null;
             payload.value_json = Array.isArray(v.value_json) ? (v.value_json as string[]) : [];
+          }
+          if (f.field_type === "mixed_list") {
+            payload.value_text = null;
+            payload.value_json = Array.isArray(v.value_json) ? (v.value_json as (string | number)[]) : [];
           }
           return payload;
         });
@@ -1936,8 +1945,199 @@ export default function DomainKpiDetailPage() {
                   Fields you can edit
                 </h3>
             {isEditing ? (
-              <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-                {[...formulaFields, ...scalarFieldsEdit].map((f) => {
+              <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                {(() => {
+                  const mixedListFields = scalarFieldsEdit.filter((f) => f.field_type === "mixed_list");
+                  const otherFields = [...formulaFields, ...scalarFieldsEdit.filter((f) => f.field_type !== "mixed_list")];
+
+                  const inferMixedAtom = (raw: string): string | number | null => {
+                    const t = (raw ?? "").trim();
+                    if (!t) return null;
+                    if (/^\d{4}-\d{2}-\d{2}$/.test(t)) return t; // ISO date
+                    const num = Number(t.replace(/,/g, ""));
+                    if (!Number.isNaN(num) && Number.isFinite(num) && /^[+-]?\d[\d,]*(\.\d+)?$/.test(t)) {
+                      return Number.isInteger(num) ? Math.trunc(num) : num;
+                    }
+                    return t;
+                  };
+
+                  const MixedListEditor = ({
+                    fieldId,
+                    fieldName,
+                    isRequired,
+                    items,
+                  }: {
+                    fieldId: number;
+                    fieldName: string;
+                    isRequired: boolean;
+                    items: (string | number)[];
+                  }) => {
+                    const [newDraft, setNewDraft] = useState("");
+                    const [editIndex, setEditIndex] = useState<number | null>(null);
+                    const [editDraft, setEditDraft] = useState<string>("");
+
+                    const addItem = () => {
+                      const atom = inferMixedAtom(newDraft);
+                      if (atom == null) return;
+                      updateField(fieldId, "value_text", null);
+                      updateField(fieldId, "value_json", [...items, atom]);
+                      setNewDraft("");
+                    };
+
+                    const removeItem = (idx: number) => {
+                      updateField(fieldId, "value_text", null);
+                      updateField(fieldId, "value_json", items.filter((_, i) => i !== idx));
+                      if (editIndex === idx) {
+                        setEditIndex(null);
+                        setEditDraft("");
+                      }
+                    };
+
+                    const startEdit = (idx: number) => {
+                      setEditIndex(idx);
+                      setEditDraft(String(items[idx] ?? ""));
+                    };
+
+                    const saveEdit = () => {
+                      if (editIndex == null) return;
+                      const atom = inferMixedAtom(editDraft);
+                      const next = [...items];
+                      if (atom == null) {
+                        // Treat empty as delete
+                        next.splice(editIndex, 1);
+                      } else {
+                        next[editIndex] = atom;
+                      }
+                      updateField(fieldId, "value_text", null);
+                      updateField(fieldId, "value_json", next);
+                      setEditIndex(null);
+                      setEditDraft("");
+                    };
+
+                    return (
+                      <div
+                        className="card"
+                        style={{
+                          padding: "0.85rem",
+                          border: "1px solid var(--border)",
+                          borderRadius: 10,
+                          background: "var(--surface)",
+                        }}
+                      >
+                        <div style={{ display: "flex", justifyContent: "space-between", gap: "0.75rem", alignItems: "center", marginBottom: "0.6rem" }}>
+                          <div style={{ fontWeight: 600 }}>
+                            {fieldName}
+                            {isRequired ? " *" : ""}
+                            <span style={{ marginLeft: "0.5rem", fontWeight: 400, color: "var(--muted)", fontSize: "0.85rem" }}>
+                              (Mixed list)
+                            </span>
+                          </div>
+                        </div>
+
+                        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", alignItems: "center", marginBottom: "0.75rem" }}>
+                          <input
+                            type="text"
+                            value={newDraft}
+                            onChange={(e) => setNewDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                e.preventDefault();
+                                addItem();
+                              }
+                            }}
+                            placeholder="Add item (text, number, or YYYY-MM-DD)"
+                            style={{
+                              flex: "1 1 260px",
+                              minWidth: 200,
+                              padding: "0.5rem",
+                              border: "1px solid var(--border)",
+                              borderRadius: 8,
+                            }}
+                          />
+                          <button type="button" className="btn btn-primary" disabled={!newDraft.trim()} onClick={addItem}>
+                            Add
+                          </button>
+                        </div>
+
+                        {items.length === 0 ? (
+                          <div style={{ color: "var(--muted)", fontSize: "0.9rem" }}>No items yet.</div>
+                        ) : (
+                          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}>
+                            <thead>
+                              <tr>
+                                <th style={{ textAlign: "left", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)", width: 48 }}>#</th>
+                                <th style={{ textAlign: "left", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)" }}>Item</th>
+                                <th style={{ textAlign: "right", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)", width: 160 }}>Actions</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {items.map((it, idx) => {
+                                const isEditingRow = editIndex === idx;
+                                return (
+                                  <tr key={`${String(it)}:${idx}`}>
+                                    <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)", color: "var(--muted)" }}>
+                                      {idx + 1}
+                                    </td>
+                                    <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)" }}>
+                                      {isEditingRow ? (
+                                        <input
+                                          type="text"
+                                          value={editDraft}
+                                          onChange={(e) => setEditDraft(e.target.value)}
+                                          style={{
+                                            width: "100%",
+                                            padding: "0.45rem 0.5rem",
+                                            borderRadius: 8,
+                                            border: "1px solid var(--border)",
+                                          }}
+                                          autoFocus
+                                        />
+                                      ) : (
+                                        <span>{String(it)}</span>
+                                      )}
+                                    </td>
+                                    <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)", textAlign: "right", whiteSpace: "nowrap" }}>
+                                      {isEditingRow ? (
+                                        <>
+                                          <button type="button" className="btn btn-primary" onClick={saveEdit} style={{ marginRight: "0.35rem" }}>
+                                            Save
+                                          </button>
+                                          <button
+                                            type="button"
+                                            className="btn"
+                                            onClick={() => {
+                                              setEditIndex(null);
+                                              setEditDraft("");
+                                            }}
+                                          >
+                                            Cancel
+                                          </button>
+                                        </>
+                                      ) : (
+                                        <>
+                                          <button type="button" className="btn" onClick={() => startEdit(idx)} style={{ marginRight: "0.35rem" }}>
+                                            Edit
+                                          </button>
+                                          <button type="button" className="btn" onClick={() => removeItem(idx)} style={{ color: "var(--error)" }}>
+                                            Delete
+                                          </button>
+                                        </>
+                                      )}
+                                    </td>
+                                  </tr>
+                                );
+                              })}
+                            </tbody>
+                          </table>
+                        )}
+                      </div>
+                    );
+                  };
+
+                  return (
+                    <>
+                      <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+                        {otherFields.map((f) => {
                     if (f.field_type === "formula") {
                       return (
                         <div key={f.id} style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
@@ -2126,7 +2326,32 @@ export default function DomainKpiDetailPage() {
                       );
                     }
                     return null;
-                  })}
+                        })}
+                      </div>
+
+                      {mixedListFields.length > 0 && (
+                        <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+                          <h4 style={{ fontSize: "0.95rem", fontWeight: 650, margin: "0.25rem 0 0", color: "var(--text)" }}>
+                            Mixed list fields
+                          </h4>
+                          {mixedListFields.map((f) => {
+                            const val = formValues[f.id];
+                            const items = Array.isArray(val?.value_json) ? (val!.value_json as (string | number)[]) : [];
+                            return (
+                              <MixedListEditor
+                                key={f.id}
+                                fieldId={f.id}
+                                fieldName={f.name}
+                                isRequired={!!f.is_required}
+                                items={items}
+                              />
+                            );
+                          })}
+                        </div>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
             ) : (
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}>

--- a/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
+++ b/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
@@ -1517,6 +1517,13 @@ export default function FullPageMultiItems() {
                           if (arr.length === 0) return "—";
                           return arr.map((x) => String(x)).join("; ");
                         }
+                        if (sf.field_type === "mixed_list") {
+                          const arr = Array.isArray(cellVal)
+                            ? (cellVal as unknown[]).filter((x) => x != null && String(x).trim() !== "")
+                            : [];
+                          if (arr.length === 0) return "—";
+                          return arr.map((x) => String(x)).join("; ");
+                        }
                         if (sf.field_type === "attachment") {
                           const url = getAttachmentUrl(cellVal);
                           if (!url) return "—";

--- a/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/row/[rowIndex]/page.tsx
+++ b/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/row/[rowIndex]/page.tsx
@@ -10,6 +10,180 @@ import { AttachmentFieldControl } from "@/components/AttachmentFieldControl";
 import { toast } from "react-toastify";
 import MultiReferenceInput from "@/components/MultiReferenceInput";
 
+type MixedAtom = string | number;
+
+function inferMixedAtom(raw: string): MixedAtom | null {
+  const t = (raw ?? "").trim();
+  if (!t) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) return t; // ISO date
+  const num = Number(t.replace(/,/g, ""));
+  if (!Number.isNaN(num) && Number.isFinite(num) && /^[+-]?\d[\d,]*(\.\d+)?$/.test(t)) {
+    return Number.isInteger(num) ? Math.trunc(num) : num;
+  }
+  return t;
+}
+
+function MixedListCellEditor({
+  label,
+  required,
+  items,
+  onChange,
+  disabled,
+}: {
+  label?: string;
+  required?: boolean;
+  items: MixedAtom[];
+  onChange: (next: MixedAtom[]) => void;
+  disabled?: boolean;
+}) {
+  const [newDraft, setNewDraft] = useState("");
+  const [editIndex, setEditIndex] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+
+  const addItem = () => {
+    const atom = inferMixedAtom(newDraft);
+    if (atom == null) return;
+    onChange([...(Array.isArray(items) ? items : []), atom]);
+    setNewDraft("");
+  };
+
+  const removeItem = (idx: number) => {
+    onChange(items.filter((_, i) => i !== idx));
+    if (editIndex === idx) {
+      setEditIndex(null);
+      setEditDraft("");
+    }
+  };
+
+  const startEdit = (idx: number) => {
+    setEditIndex(idx);
+    setEditDraft(String(items[idx] ?? ""));
+  };
+
+  const saveEdit = () => {
+    if (editIndex == null) return;
+    const atom = inferMixedAtom(editDraft);
+    const next = [...items];
+    if (atom == null) {
+      next.splice(editIndex, 1);
+    } else {
+      next[editIndex] = atom;
+    }
+    onChange(next);
+    setEditIndex(null);
+    setEditDraft("");
+  };
+
+  return (
+    <div className="form-group">
+      {label ? (
+        <label>
+          {label}
+          {required ? " *" : ""}
+        </label>
+      ) : null}
+
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", alignItems: "center", marginBottom: "0.6rem" }}>
+        <input
+          type="text"
+          value={newDraft}
+          disabled={disabled}
+          onChange={(e) => setNewDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              if (!disabled) addItem();
+            }
+          }}
+          placeholder="Add item (text, number, or YYYY-MM-DD)"
+          style={{
+            flex: "1 1 260px",
+            minWidth: 200,
+            padding: "0.5rem",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+          }}
+        />
+        <button type="button" className="btn btn-primary" disabled={disabled || !newDraft.trim()} onClick={addItem}>
+          Add
+        </button>
+      </div>
+
+      {items.length === 0 ? (
+        <div style={{ color: "var(--muted)", fontSize: "0.9rem" }}>No items yet.</div>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: "left", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)", width: 48 }}>#</th>
+              <th style={{ textAlign: "left", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)" }}>Item</th>
+              <th style={{ textAlign: "right", padding: "0.45rem 0.4rem", borderBottom: "1px solid var(--border)", width: 160 }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((it, idx) => {
+              const isEditingRow = editIndex === idx;
+              return (
+                <tr key={`${String(it)}:${idx}`}>
+                  <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)", color: "var(--muted)" }}>{idx + 1}</td>
+                  <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)" }}>
+                    {isEditingRow ? (
+                      <input
+                        type="text"
+                        value={editDraft}
+                        disabled={disabled}
+                        onChange={(e) => setEditDraft(e.target.value)}
+                        style={{
+                          width: "100%",
+                          padding: "0.45rem 0.5rem",
+                          borderRadius: 8,
+                          border: "1px solid var(--border)",
+                        }}
+                        autoFocus
+                      />
+                    ) : (
+                      <span>{String(it)}</span>
+                    )}
+                  </td>
+                  <td style={{ padding: "0.4rem", borderBottom: "1px solid var(--border)", textAlign: "right", whiteSpace: "nowrap" }}>
+                    {isEditingRow ? (
+                      <>
+                        <button type="button" className="btn btn-primary" disabled={disabled} onClick={saveEdit} style={{ marginRight: "0.35rem" }}>
+                          Save
+                        </button>
+                        <button
+                          type="button"
+                          className="btn"
+                          disabled={disabled}
+                          onClick={() => {
+                            setEditIndex(null);
+                            setEditDraft("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button type="button" className="btn" disabled={disabled} onClick={() => startEdit(idx)} style={{ marginRight: "0.35rem" }}>
+                          Edit
+                        </button>
+                        <button type="button" className="btn" disabled={disabled} onClick={() => removeItem(idx)} style={{ color: "var(--error)" }}>
+                          Delete
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
 type SubField = {
   key: string;
   name: string;
@@ -473,6 +647,9 @@ export default function MultiItemRowDetail() {
                   } else if (sf.field_type === "multi_reference") {
                     const arr = Array.isArray(val) ? (val as unknown[]).filter((x) => x != null && String(x).trim() !== "") : [];
                     display = arr.length > 0 ? arr.map((x) => String(x)).join("; ") : "—";
+                  } else if (sf.field_type === "mixed_list") {
+                    const arr = Array.isArray(val) ? (val as unknown[]).filter((x) => x != null && String(x).trim() !== "") : [];
+                    display = arr.length > 0 ? arr.map((x) => String(x)).join("; ") : "—";
                   } else {
                     display = val != null && String(val).trim() !== "" ? String(val) : "—";
                   }
@@ -556,7 +733,10 @@ export default function MultiItemRowDetail() {
                 }}
               >
                 {(() => {
-                  const compactFields = group.fields.filter((sf) => sf.field_type !== "multi_line_text");
+                  const mixedListFields = group.fields.filter((sf) => sf.field_type === "mixed_list");
+                  const compactFields = group.fields.filter(
+                    (sf) => sf.field_type !== "multi_line_text" && sf.field_type !== "mixed_list"
+                  );
                   const multiLineFields = group.fields.filter((sf) => sf.field_type === "multi_line_text");
 
                   // Place multi-line textareas into two columns, 1 textarea per column cell (balanced).
@@ -775,6 +955,34 @@ export default function MultiItemRowDetail() {
                           </div>
                         </div>
                       )}
+
+                      {mixedListFields.map((sf) => {
+                        const key = sf.key;
+                        const val = editData[key];
+                        return (
+                          <div
+                            key={key}
+                            style={{
+                              padding: "0.85rem",
+                              border: "1px solid var(--border)",
+                              borderRadius: 10,
+                              background: "var(--surface)",
+                            }}
+                          >
+                            <div style={{ fontSize: "0.95rem", fontWeight: 650, marginBottom: "0.6rem" }}>
+                              {sf.name}
+                              {sf.is_required ? " *" : ""}
+                            </div>
+                            <MixedListCellEditor
+                              label=""  // heading is rendered by the card title above
+                              required={false}
+                              items={Array.isArray(val) ? (val as MixedAtom[]) : []}
+                              onChange={(next) => handleChangeCell(key, next)}
+                              disabled={sf.can_edit === false}
+                            />
+                          </div>
+                        );
+                      })}
 
                       {multiLineFields.length > 0 && (
                         <div

--- a/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
+++ b/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
@@ -27,11 +27,12 @@ const FIELD_TYPES = [
   "attachment",
   "reference",
   "multi_reference",
+  "mixed_list",
   "multi_line_items",
   "formula",
 ] as const;
 
-const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference", "attachment"] as const;
+const SUB_FIELD_TYPES = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference", "attachment", "mixed_list"] as const;
 
 function slugifyKey(name: string): string {
   if (!name) return "";
@@ -2003,7 +2004,7 @@ function ReferenceConfigUI({
       .then((list) => setSourceFields(list))
       .catch(() => setSourceFields([]));
   }, [token, organizationId, value.reference_source_kpi_id]);
-  const scalarFieldTypes = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference"];
+  const scalarFieldTypes = ["single_line_text", "multi_line_text", "number", "date", "boolean", "reference", "multi_reference", "mixed_list"];
   const sourceFieldOptions: { value: string; label: string }[] = [];
   sourceFields.forEach((f) => {
     if (scalarFieldTypes.includes(f.field_type)) {

--- a/frontend/src/components/DynamicKpiForm.tsx
+++ b/frontend/src/components/DynamicKpiForm.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useFormContext } from "react-hook-form";
+import MixedListInput from "@/components/MixedListInput";
 
 export type FieldType =
   | "single_line_text"
@@ -13,6 +14,7 @@ export type FieldType =
   | "number"
   | "date"
   | "boolean"
+  | "mixed_list"
   | "multi_line_items"
   | "formula";
 
@@ -33,7 +35,7 @@ interface Props {
 }
 
 export default function DynamicKpiForm({ fields, disabled }: Props) {
-  const { register, formState: { errors } } = useFormContext();
+  const { register, setValue, watch, formState: { errors } } = useFormContext();
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -142,6 +144,26 @@ export default function DynamicKpiForm({ fields, disabled }: Props) {
                 {...register(`${name}.value_text`)}
                 disabled={disabled}
                 rows={4}
+              />
+              {err && <p className="form-error">{(err as { message?: string }).message}</p>}
+            </div>
+          );
+        }
+
+        if (f.field_type === "mixed_list") {
+          const current = watch(`${name}.value_json`) as unknown;
+          const arr = Array.isArray(current) ? (current as (string | number)[]) : [];
+          return (
+            <div key={f.id} className="form-group">
+              <label htmlFor={name}>{f.name}{f.is_required ? " *" : ""}</label>
+              <MixedListInput
+                value={arr}
+                disabled={disabled}
+                onChange={(next) => {
+                  setValue(`${name}.value_text`, null, { shouldDirty: true });
+                  setValue(`${name}.value_json`, next, { shouldDirty: true });
+                }}
+                placeholder="Type a value and click Add"
               />
               {err && <p className="form-error">{(err as { message?: string }).message}</p>}
             </div>

--- a/frontend/src/components/MixedListInput.tsx
+++ b/frontend/src/components/MixedListInput.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+type MixedAtom = string | number;
+
+type Props = {
+  value: MixedAtom[];
+  onChange: (next: MixedAtom[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+};
+
+function isIsoDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s.trim());
+}
+
+function inferAtom(raw: string): MixedAtom | null {
+  const t = raw.trim();
+  if (!t) return null;
+  if (isIsoDate(t)) return t; // keep as ISO date string
+  const num = Number(t.replace(/,/g, ""));
+  if (!Number.isNaN(num) && Number.isFinite(num) && t.match(/^[+-]?\d[\d,]*(\.\d+)?$/)) {
+    // Preserve ints as ints
+    if (Number.isInteger(num)) return num;
+    return num;
+  }
+  return t;
+}
+
+function atomKey(a: MixedAtom): string {
+  return typeof a === "number" ? `n:${a}` : `s:${a}`;
+}
+
+export default function MixedListInput({ value, onChange, disabled, placeholder }: Props) {
+  const [draft, setDraft] = useState("");
+
+  const canAdd = useMemo(() => {
+    const atom = inferAtom(draft);
+    return atom !== null;
+  }, [draft]);
+
+  const add = () => {
+    const atom = inferAtom(draft);
+    if (atom == null) return;
+    onChange([...(Array.isArray(value) ? value : []), atom]);
+    setDraft("");
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", minWidth: 0 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.3rem", alignItems: "center" }}>
+        {(Array.isArray(value) ? value : []).map((v, idx) => (
+          <span
+            key={`${atomKey(v)}:${idx}`}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.25rem",
+              padding: "0.15rem 0.45rem",
+              borderRadius: 12,
+              background: "var(--bg-subtle, #f3f4f6)",
+              fontSize: "0.8rem",
+              maxWidth: "100%",
+            }}
+            title={String(v)}
+          >
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{String(v)}</span>
+            {!disabled && (
+              <button
+                type="button"
+                aria-label={`Remove ${String(v)}`}
+                onClick={() => onChange(value.filter((_, i) => i !== idx))}
+                style={{
+                  border: "none",
+                  background: "transparent",
+                  cursor: "pointer",
+                  padding: 0,
+                  lineHeight: 1,
+                  color: "var(--danger, #b91c1c)",
+                }}
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+      </div>
+
+      {!disabled && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "0.35rem", alignItems: "center" }}>
+          <input
+            type="text"
+            value={draft}
+            placeholder={placeholder ?? "Type a value (text, number, or YYYY-MM-DD)"}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                add();
+              }
+            }}
+            style={{
+              flex: "1 1 160px",
+              minWidth: 120,
+              padding: "0.35rem 0.5rem",
+              borderRadius: 6,
+              border: "1px solid var(--border)",
+              fontSize: "0.85rem",
+            }}
+          />
+          <button
+            type="button"
+            className="btn"
+            style={{ padding: "0.3rem 0.55rem", fontSize: "0.8rem" }}
+            disabled={!canAdd}
+            onClick={add}
+          >
+            Add
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/lib/multiItemsApiExample.ts
+++ b/frontend/src/lib/multiItemsApiExample.ts
@@ -29,6 +29,8 @@ export function sampleValueForSubField(fieldType: string | null | undefined, row
       return r === 0 ? "example_ref_token_alpha" : "example_ref_token_beta";
     case "multi_reference":
       return r === 0 ? ["Alpha", "Beta"] : ["Gamma"];
+    case "mixed_list":
+      return r === 0 ? ["Sample text", 123, "2026-04-01"] : ["Other", 456, "2026-05-10"];
     case "attachment":
       return null;
     case "multi_line_text":


### PR DESCRIPTION
- Introduced a new field type 'mixed_list' to the FieldType enum, allowing for heterogeneous JSON lists containing strings, numbers, and ISO date strings.
- Implemented database migration to add 'mixed_list' to the fieldtype enum.
- Updated various components and services to handle 'mixed_list' values, including serialization, deserialization, and UI input handling.
- Enhanced API contract and schemas to support the new field type, ensuring proper data handling across the application.
- Added a MixedListInput component for user-friendly input of mixed list values in the frontend.