### PR TITLE
Add Odoo integration for KPI and organization configurations

### DIFF
--- a/backend/alembic/versions/039_chat_nl_tables.py
+++ b/backend/alembic/versions/039_chat_nl_tables.py
@@ -1,0 +1,21 @@
+"""Chat NL query tables (stub — revision kept for DB compatibility).
+
+Revision ID: 039_chat_nl
+Revises: 038_mline_row_search
+Create Date: 2026-05-24
+"""
+
+from alembic import op
+
+revision = "039_chat_nl"
+down_revision = "038_mline_row_search"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/040_odoo_integration.py
+++ b/backend/alembic/versions/040_odoo_integration.py
@@ -1,0 +1,60 @@
+"""Odoo integration tables.
+
+Revision ID: 040_odoo_integration
+Revises: 039_chat_nl
+Create Date: 2026-05-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "040_odoo_integration"
+down_revision = "039_chat_nl"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "organization_odoo_configs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("login_url", sa.String(length=2048), nullable=False),
+        sa.Column("data_fetch_url", sa.String(length=2048), nullable=False),
+        sa.Column("odoo_db", sa.String(length=255), nullable=True),
+        sa.Column("username", sa.String(length=255), nullable=False),
+        sa.Column("password", sa.String(length=512), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", name="uq_org_odoo_config_org_id"),
+    )
+    op.create_index(
+        op.f("ix_organization_odoo_configs_organization_id"),
+        "organization_odoo_configs",
+        ["organization_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "kpi_odoo_configs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("kpi_id", sa.Integer(), nullable=False),
+        sa.Column("request_body", sa.JSON(), nullable=False),
+        sa.Column("response_items_path", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["kpi_id"], ["kpis.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kpi_id", name="uq_kpi_odoo_config_kpi_id"),
+    )
+    op.create_index(op.f("ix_kpi_odoo_configs_kpi_id"), "kpi_odoo_configs", ["kpi_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_kpi_odoo_configs_kpi_id"), table_name="kpi_odoo_configs")
+    op.drop_table("kpi_odoo_configs")
+    op.drop_index(op.f("ix_organization_odoo_configs_organization_id"), table_name="organization_odoo_configs")
+    op.drop_table("organization_odoo_configs")

--- a/backend/app/core/models.py
+++ b/backend/app/core/models.py
@@ -126,6 +126,12 @@ class Organization(Base):
         uselist=False,
         lazy="selectin",
     )
+    odoo_config = relationship(
+        "OrganizationOdooConfig",
+        back_populates="organization",
+        uselist=False,
+        lazy="selectin",
+    )
 
 
 class OrganizationStorageConfig(Base):
@@ -147,6 +153,30 @@ class OrganizationStorageConfig(Base):
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 
     organization = relationship("Organization", back_populates="storage_config")
+
+
+class OrganizationOdooConfig(Base):
+    """Per-organization Odoo XML-RPC/API connection (Super Admin)."""
+
+    __tablename__ = "organization_odoo_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    organization_id = Column(
+        Integer,
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        unique=True,
+    )
+    login_url = Column(String(2048), nullable=False)
+    data_fetch_url = Column(String(2048), nullable=False)
+    odoo_db = Column(String(255), nullable=True)
+    username = Column(String(255), nullable=False)
+    password = Column(String(512), nullable=False)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
+
+    organization = relationship("Organization", back_populates="odoo_config")
 
 
 class ExportAPIToken(Base):
@@ -436,6 +466,29 @@ class KPI(Base):
     entries = relationship("KPIEntry", back_populates="kpi", lazy="selectin")
     kpi_files = relationship("KpiFile", back_populates="kpi", lazy="selectin")
     report_template_kpis = relationship("ReportTemplateKPI", back_populates="kpi", lazy="selectin")
+    odoo_config = relationship(
+        "KpiOdooConfig",
+        back_populates="kpi",
+        uselist=False,
+        lazy="selectin",
+    )
+
+
+class KpiOdooConfig(Base):
+    """KPI-specific Odoo data fetch JSON body (Org Admin only)."""
+
+    __tablename__ = "kpi_odoo_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    kpi_id = Column(
+        Integer, ForeignKey("kpis.id", ondelete="CASCADE"), nullable=False, index=True, unique=True
+    )
+    request_body = Column(JSON, nullable=False)
+    response_items_path = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
+
+    kpi = relationship("KPI", back_populates="odoo_config")
 
 
 class KPIField(Base):

--- a/backend/app/entries/routes.py
+++ b/backend/app/entries/routes.py
@@ -41,8 +41,15 @@ from app.core.models import (
     utc_now,
 )
 from app.entries.schemas import EntryCreate, EntrySubmit, EntryLock, EntryResponse, FieldValueResponse
+from app.core.models import UserRole
+from app.odoo.service import sanitize_multi_items_field_config
 
 logger = logging.getLogger("uvicorn.error")
+
+
+def _field_config_for_user(config: dict | None, user: User) -> dict | None:
+    is_admin = user.role in (UserRole.SUPER_ADMIN, UserRole.ORG_ADMIN)
+    return sanitize_multi_items_field_config(config, is_admin)
 
 # Cap for list_multi_items_rows(fetch_all=True) to bound memory and payload size.
 _MULTI_ITEMS_FETCH_ALL_CAP = 50_000
@@ -2222,6 +2229,197 @@ async def sync_multi_items_from_api(
     return out
 
 
+@router.get("/multi-items/import-capabilities")
+async def multi_items_import_capabilities(
+    field_id: int = Query(...),
+    kpi_id: int = Query(...),
+    organization_id: int | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Which bulk import channels are available for a multi-line field (no secrets)."""
+    from app.odoo.config_service import get_org_odoo_config, get_kpi_odoo_config
+
+    org_id = _org_id(current_user, organization_id)
+    field_res = await db.execute(
+        select(KPIField)
+        .join(KPI, KPI.id == KPIField.kpi_id)
+        .where(KPIField.id == field_id, KPIField.kpi_id == kpi_id, KPI.organization_id == org_id)
+    )
+    field = field_res.scalar_one_or_none()
+    if not field or field.field_type != FieldType.multi_line_items:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Multi-line field not found")
+
+    cfg = getattr(field, "config", None) or {}
+    channel = (cfg.get("multi_items_import_channel") or "excel").strip().lower()
+    if cfg.get("multi_items_api_endpoint_url"):
+        channels = ["excel", "api", "previous_year"]
+    else:
+        channels = ["excel", "previous_year"]
+
+    org_odoo = await get_org_odoo_config(db, org_id)
+    kpi_odoo = await get_kpi_odoo_config(db, kpi_id)
+    odoo_org_configured = org_odoo is not None
+    odoo_kpi_configured = kpi_odoo is not None
+    odoo_ready = odoo_org_configured and odoo_kpi_configured
+    if odoo_ready:
+        channels.append("odoo")
+
+    odoo_blockers: list[str] = []
+    if current_user.role == UserRole.SUPER_ADMIN:
+        if not odoo_org_configured:
+            odoo_blockers.append(
+                "Organization Odoo connection is not configured. Save it under Organization → Settings → Odoo integration."
+            )
+        if not odoo_kpi_configured:
+            odoo_blockers.append(
+                "KPI Odoo request body is not configured. Save it on the KPI Fields page under Odoo bulk import."
+            )
+    elif not odoo_ready:
+        odoo_blockers.append(
+            "Odoo is not configured for this KPI. Ask your Super Admin to configure it first."
+        )
+
+    can_configure = current_user.role == UserRole.SUPER_ADMIN
+    return {
+        "import_channel": channel,
+        "channels": sorted(set(channels)),
+        "odoo_ready": odoo_ready,
+        "odoo_org_configured": odoo_org_configured,
+        "odoo_kpi_configured": odoo_kpi_configured,
+        "odoo_blockers": odoo_blockers,
+        "api_configured": bool((cfg.get("multi_items_api_endpoint_url") or "").strip()),
+        "can_configure": can_configure,
+    }
+
+
+@router.post("/multi-items/sync-from-odoo")
+async def sync_multi_items_from_odoo(
+    entry_id: int = Query(...),
+    field_id: int = Query(...),
+    organization_id: int | None = Query(None),
+    sync_mode: str = Query(
+        "override",
+        description="override = replace existing; append = append rows; upsert = update by match_sub_field_key or add",
+        pattern="^(override|append|upsert)$",
+    ),
+    match_sub_field_key: str | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Sync multi_line_items from Odoo using org connection + KPI request body + field mappings."""
+    from app.odoo.config_service import get_org_odoo_config, get_kpi_odoo_config
+    from app.odoo.service import (
+        odoo_authenticate,
+        odoo_fetch_items,
+        apply_odoo_field_mappings,
+        apply_odoo_sub_field_mappings,
+    )
+    from app.entries.service import user_can_add_row_multi_line_field, user_can_edit_multi_line_field
+
+    org_id = _org_id(current_user, organization_id)
+    entry_res = await db.execute(
+        select(KPIEntry).where(KPIEntry.id == entry_id, KPIEntry.organization_id == org_id)
+    )
+    entry = entry_res.scalar_one_or_none()
+    if not entry or entry.is_locked:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Entry not editable")
+
+    field = await _load_multi_items_field(db, org_id, field_id)
+    if not field or field.kpi_id != entry.kpi_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Multi-line field not found")
+
+    can_add = await user_can_add_row_multi_line_field(db, current_user.id, field.kpi_id, field.id)
+    if not can_add:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not allowed to add rows to this field")
+    can_edit = await user_can_edit_multi_line_field(db, current_user.id, entry.kpi_id, field)
+    if not can_edit:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not allowed to edit this field")
+
+    cfg = getattr(field, "config", None) or {}
+    channel = (cfg.get("multi_items_import_channel") or "").strip().lower()
+    if channel != "odoo":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This field is not configured to use Odoo as import channel",
+        )
+
+    org_odoo = await get_org_odoo_config(db, org_id)
+    kpi_odoo = await get_kpi_odoo_config(db, field.kpi_id)
+    if not org_odoo or not kpi_odoo:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Odoo is not fully configured for this organization/KPI")
+
+    try:
+        session_id = await odoo_authenticate(org_odoo)
+        context = {
+            "year": entry.year,
+            "kpi_id": field.kpi_id,
+            "organization_id": org_id,
+            "entry_id": entry.id,
+            "field_id": field.id,
+            "field_key": field.key,
+        }
+        raw_items = await odoo_fetch_items(org_odoo, kpi_odoo, session_id, context)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e)) from e
+
+    sub_keys = {s.key for s in (field.sub_fields or [])}
+    sub_mappings = cfg.get("odoo_sub_field_mappings") or {}
+    if isinstance(sub_mappings, dict) and sub_mappings:
+        item_dicts = apply_odoo_sub_field_mappings(raw_items, sub_mappings, sub_keys)
+    else:
+        mappings = cfg.get("odoo_field_mappings") or {}
+        if not isinstance(mappings, dict):
+            mappings = {}
+        list_indices_raw = cfg.get("odoo_field_list_indices") or {}
+        list_indices: dict[str, int] = {}
+        if isinstance(list_indices_raw, dict):
+            for odoo_key, idx in list_indices_raw.items():
+                if isinstance(idx, int):
+                    list_indices[str(odoo_key)] = idx
+                elif isinstance(idx, str) and idx.isdigit():
+                    list_indices[str(odoo_key)] = int(idx)
+        item_dicts = apply_odoo_field_mappings(raw_items, mappings, sub_keys, list_indices)
+    item_dicts = [
+        dict(x)
+        for x in item_dicts
+        if isinstance(x, dict) and not _is_multi_items_row_effectively_empty(dict(x))
+    ]
+
+    existing_pairs = await _load_multi_line_row_dicts(db, entry_id=entry.id, field=field)
+    existing_rows: list[dict] = [r for _, r in existing_pairs] if existing_pairs else []
+
+    effective_mode = (sync_mode or "override").lower()
+    if effective_mode == "upsert":
+        mk = (match_sub_field_key or "").strip()
+        if not mk:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="match_sub_field_key is required when sync_mode=upsert")
+        sub_by_key = {s.key: s for s in (field.sub_fields or [])}
+        if mk not in sub_by_key:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="match_sub_field_key must be a defined sub-field key")
+        match_ft = getattr(sub_by_key[mk], "field_type", None)
+        new_rows, rows_updated, rows_added = _upsert_merge_multi_line_items(
+            existing_rows, item_dicts, mk, match_ft
+        )
+    elif effective_mode == "append":
+        new_rows = existing_rows + item_dicts
+        rows_updated = 0
+        rows_added = len(item_dicts)
+    else:
+        new_rows = item_dicts
+        rows_updated = 0
+        rows_added = len(item_dicts)
+
+    await _replace_multi_line_rows_from_dicts(db, entry_id=entry.id, field=field, rows=new_rows)
+    await recompute_formula_fields_for_entry(db, entry_id=entry.id, org_id=org_id)
+    await db.commit()
+    out: dict = {"entry_id": entry.id, "field_id": field.id, "rows_imported": len(item_dicts)}
+    if effective_mode == "upsert":
+        out["rows_updated"] = rows_updated
+        out["rows_appended"] = rows_added
+    return out
+
+
 @router.post("/multi-items/import-from-year")
 async def import_multi_items_from_year(
     entry_id: int = Query(...),
@@ -2856,7 +3054,7 @@ async def get_entry_fields(
                 "formula_expression": f.formula_expression,
                 "is_required": f.is_required,
                 "sort_order": f.sort_order,
-                "config": getattr(f, "config", None),
+                "config": _field_config_for_user(getattr(f, "config", None), current_user),
                 "carry_forward_data": getattr(f, "carry_forward_data", False),
                 "full_page_multi_items": getattr(f, "full_page_multi_items", False),
                 "row_level_user_access_enabled": getattr(f, "row_level_user_access_enabled", False),
@@ -2908,7 +3106,7 @@ async def get_entry_fields(
             "formula_expression": f.formula_expression,
             "is_required": f.is_required,
             "sort_order": f.sort_order,
-            "config": getattr(f, "config", None),
+            "config": _field_config_for_user(getattr(f, "config", None), current_user),
             "carry_forward_data": getattr(f, "carry_forward_data", False),
             "full_page_multi_items": getattr(f, "full_page_multi_items", False),
             "row_level_user_access_enabled": getattr(f, "row_level_user_access_enabled", False),

--- a/backend/app/fields/routes.py
+++ b/backend/app/fields/routes.py
@@ -52,6 +52,7 @@ async def get_reference_allowed_values(
     source_kpi_id: int = Query(..., description="KPI id of the source field"),
     source_field_key: str = Query(..., description="Field key of the source field"),
     source_sub_field_key: str | None = Query(None, description="Sub-field key when source is multi_line_items"),
+    year: int | None = Query(None, ge=2000, le=2100, description="Limit reference values to entries for this year"),
     organization_id: int | None = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -60,7 +61,7 @@ async def get_reference_allowed_values(
     """Return distinct values from a source KPI field (or multi_line_items sub-field) for reference/lookup dropdown."""
     org_id = _org_id(current_user, organization_id)
     from app.entries.service import get_reference_allowed_values as get_allowed
-    values = await get_allowed(db, source_kpi_id, source_field_key, org_id, source_sub_field_key)
+    values = await get_allowed(db, source_kpi_id, source_field_key, org_id, source_sub_field_key, year=year)
     return ReferenceAllowedValuesResponse(values=values)
 
 

--- a/backend/app/kpis/routes.py
+++ b/backend/app/kpis/routes.py
@@ -3,6 +3,7 @@
 import re
 import uuid
 from datetime import datetime
+from io import BytesIO
 from fastapi import APIRouter, Depends, HTTPException, status, Query, UploadFile, File, Form
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -10,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.core.database import get_db
-from app.auth.dependencies import require_org_admin, get_current_user, get_data_export_auth, DataExportAuth
+from app.auth.dependencies import require_org_admin, require_super_admin, get_current_user, get_data_export_auth, DataExportAuth
 from app.core.models import User, KPI, KpiFile
 from app.entries.service import user_can_view_kpi, user_can_edit_kpi, parse_upsert_match_keys_json
 from app.kpis.schemas import (
@@ -39,6 +40,11 @@ from app.kpis.schemas import (
     AssignedRoleRef,
     UsedInReportRef,
     KpiFileResponse,
+    KpiOdooConfigUpdate,
+    KpiOdooConfigResponse,
+    KpiOdooConfigStatus,
+    KpiOdooPreviewRequest,
+    KpiOdooPreviewResponse,
 )
 from app.kpis.service import (
     create_kpi,
@@ -77,7 +83,7 @@ from app.kpis.service import (
     sync_kpi_entry_from_api,
 )
 from app.users.schemas import UserResponse
-from app.fields.service import list_fields as list_kpi_fields
+from app.fields.service import list_fields as list_kpi_fields, get_field as get_kpi_field
 from app.core.models import FieldType
 from app.storage.service import upload_file as storage_upload_file, delete_file as storage_delete_file, get_file_stream as storage_get_file_stream
 
@@ -868,6 +874,210 @@ async def get_kpi_api_contract(
             "year": example_year,
             "values": example_values,
         },
+    )
+
+
+@router.get("/{kpi_id}/odoo-config", response_model=KpiOdooConfigResponse)
+async def get_kpi_odoo_config_route(
+    kpi_id: int,
+    organization_id: int | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Get KPI Odoo request body config (Super Admin only)."""
+    from app.odoo.config_service import get_kpi_odoo_config, kpi_belongs_to_org
+
+    org_id = _org_id(current_user, organization_id)
+    if not await kpi_belongs_to_org(db, kpi_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="KPI not found")
+    cfg = await get_kpi_odoo_config(db, kpi_id)
+    if not cfg:
+        return KpiOdooConfigResponse(kpi_id=kpi_id, configured=False)
+    return KpiOdooConfigResponse(
+        kpi_id=kpi_id,
+        configured=True,
+        request_body=cfg.request_body,
+        response_items_path=cfg.response_items_path,
+    )
+
+
+@router.get("/{kpi_id}/odoo-config/status", response_model=KpiOdooConfigStatus)
+async def get_kpi_odoo_config_status_route(
+    kpi_id: int,
+    organization_id: int | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Odoo config readiness without exposing request body (any KPI viewer)."""
+    from app.odoo.config_service import get_kpi_odoo_config, kpi_belongs_to_org
+
+    org_id = _org_id(current_user, organization_id)
+    if not await kpi_belongs_to_org(db, kpi_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="KPI not found")
+    cfg = await get_kpi_odoo_config(db, kpi_id)
+    return KpiOdooConfigStatus(kpi_id=kpi_id, configured=cfg is not None)
+
+
+@router.put("/{kpi_id}/odoo-config", response_model=KpiOdooConfigResponse)
+async def update_kpi_odoo_config_route(
+    kpi_id: int,
+    body: KpiOdooConfigUpdate,
+    organization_id: int | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Set KPI-specific Odoo JSON request body (Super Admin only)."""
+    from app.odoo.config_service import upsert_kpi_odoo_config, kpi_belongs_to_org
+
+    org_id = _org_id(current_user, organization_id)
+    if not await kpi_belongs_to_org(db, kpi_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="KPI not found")
+    cfg = await upsert_kpi_odoo_config(
+        db, kpi_id, body.request_body, (body.response_items_path or "").strip() or None
+    )
+    await db.commit()
+    return KpiOdooConfigResponse(
+        kpi_id=kpi_id,
+        configured=True,
+        request_body=cfg.request_body,
+        response_items_path=cfg.response_items_path,
+    )
+
+
+async def _fetch_kpi_odoo_preview_items(
+    db: AsyncSession,
+    *,
+    kpi_id: int,
+    field_id: int,
+    org_id: int,
+    year: int | None,
+    body: KpiOdooPreviewRequest | None,
+):
+    """Load Odoo rows for KPI preview/export (Super Admin). Returns (field, raw_items)."""
+    from types import SimpleNamespace
+
+    from app.odoo.config_service import get_org_odoo_config, get_kpi_odoo_config, kpi_belongs_to_org
+    from app.odoo.service import odoo_authenticate, odoo_fetch_items
+
+    if not await kpi_belongs_to_org(db, kpi_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="KPI not found")
+
+    field = await get_kpi_field(db, field_id, org_id)
+    if not field or field.kpi_id != kpi_id or field.field_type != FieldType.multi_line_items:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Multi-line field not found")
+
+    org_odoo = await get_org_odoo_config(db, org_id)
+    if not org_odoo:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Organization Odoo connection is not configured",
+        )
+
+    saved_kpi_odoo = await get_kpi_odoo_config(db, kpi_id)
+    preview_body = body.request_body if body and body.request_body is not None else None
+    preview_path = (body.response_items_path or "").strip() if body else ""
+    if preview_body is None:
+        if not saved_kpi_odoo:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Save the KPI Odoo request body first, or send request_body in the preview request",
+            )
+        request_body = saved_kpi_odoo.request_body
+        response_items_path = saved_kpi_odoo.response_items_path
+    else:
+        request_body = preview_body
+        response_items_path = preview_path or (saved_kpi_odoo.response_items_path if saved_kpi_odoo else None)
+
+    preview_year = year if year is not None else datetime.utcnow().year
+    kpi_cfg = SimpleNamespace(request_body=request_body, response_items_path=response_items_path)
+
+    try:
+        session_id = await odoo_authenticate(org_odoo)
+        context = {
+            "year": preview_year,
+            "kpi_id": kpi_id,
+            "organization_id": org_id,
+            "entry_id": 0,
+            "field_id": field.id,
+            "field_key": field.key,
+        }
+        raw_items = await odoo_fetch_items(org_odoo, kpi_cfg, session_id, context)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e)) from e
+
+    return field, raw_items, preview_year
+
+
+@router.post("/{kpi_id}/odoo-preview", response_model=KpiOdooPreviewResponse)
+async def preview_kpi_odoo_data_route(
+    kpi_id: int,
+    field_id: int = Query(..., description="Multi-line items field used for __FIELD_ID__ / __FIELD_KEY__ placeholders"),
+    year: int | None = Query(None, ge=2000, le=2100),
+    organization_id: int | None = Query(None),
+    body: KpiOdooPreviewRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Fetch sample Odoo rows for column discovery and mapping (Super Admin only). Does not write data."""
+    from app.odoo.service import (
+        extract_odoo_columns,
+        build_odoo_preview_rows,
+        detect_odoo_list_columns,
+    )
+
+    org_id = _org_id(current_user, organization_id)
+    _, raw_items, _ = await _fetch_kpi_odoo_preview_items(
+        db,
+        kpi_id=kpi_id,
+        field_id=field_id,
+        org_id=org_id,
+        year=year,
+        body=body,
+    )
+
+    columns = extract_odoo_columns(raw_items)
+    sample_rows, preview_column_count = build_odoo_preview_rows(raw_items, columns, max_rows=5, max_columns=7)
+    list_columns = detect_odoo_list_columns(raw_items, columns)
+    return KpiOdooPreviewResponse(
+        columns=columns,
+        sample_rows=sample_rows,
+        total_rows=len(raw_items),
+        preview_row_count=len(sample_rows),
+        preview_column_count=preview_column_count,
+        list_columns=list_columns,
+    )
+
+
+@router.post("/{kpi_id}/odoo-preview-export")
+async def export_kpi_odoo_preview_excel_route(
+    kpi_id: int,
+    field_id: int = Query(..., description="Multi-line items field used for __FIELD_ID__ / __FIELD_KEY__ placeholders"),
+    year: int | None = Query(None, ge=2000, le=2100),
+    organization_id: int | None = Query(None),
+    body: KpiOdooPreviewRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Download all Odoo sample rows and columns as Excel (Super Admin only)."""
+    from app.odoo.service import extract_odoo_columns, build_odoo_sample_xlsx_bytes
+
+    org_id = _org_id(current_user, organization_id)
+    field, raw_items, preview_year = await _fetch_kpi_odoo_preview_items(
+        db,
+        kpi_id=kpi_id,
+        field_id=field_id,
+        org_id=org_id,
+        year=year,
+        body=body,
+    )
+
+    columns = extract_odoo_columns(raw_items)
+    xlsx_bytes = build_odoo_sample_xlsx_bytes(raw_items, columns)
+    filename = f"odoo_sample_kpi{kpi_id}_{field.key}_{preview_year}.xlsx"
+    return StreamingResponse(
+        BytesIO(xlsx_bytes),
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/backend/app/kpis/schemas.py
+++ b/backend/app/kpis/schemas.py
@@ -286,3 +286,62 @@ class KpiFileResponse(BaseModel):
     content_type: str | None
     created_at: str
     download_url: str | None = None  # relative path for download endpoint
+
+
+class KpiOdooConfigUpdate(BaseModel):
+    """KPI-specific Odoo fetch request body (Super Admin only)."""
+
+    request_body: dict | list = Field(..., description="JSON body sent to Odoo data fetch URL")
+    response_items_path: str | None = Field(
+        None,
+        max_length=255,
+        description="Dot path to items list in response, e.g. result.records; default auto-detect",
+    )
+
+
+class KpiOdooConfigResponse(BaseModel):
+    """Full Odoo KPI config (Org Admin)."""
+
+    kpi_id: int
+    configured: bool
+    request_body: dict | list | None = None
+    response_items_path: str | None = None
+
+
+class KpiOdooPreviewRequest(BaseModel):
+    """Optional overrides when previewing Odoo data before saving KPI config."""
+
+    request_body: dict | list | None = None
+    response_items_path: str | None = Field(
+        None,
+        max_length=255,
+        description="Dot path to items list in response; uses saved config when omitted",
+    )
+
+
+class OdooListColumnPart(BaseModel):
+    """One index option for an Odoo column that returns list/tuple values."""
+
+    index: int
+    sample: str
+
+
+class KpiOdooPreviewResponse(BaseModel):
+    """Sample Odoo rows for mapping UI (no credentials)."""
+
+    columns: list[str]
+    sample_rows: list[dict[str, str]]
+    total_rows: int
+    preview_row_count: int
+    preview_column_count: int
+    list_columns: dict[str, list[OdooListColumnPart]] = Field(
+        default_factory=dict,
+        description="Odoo columns with list/tuple values (e.g. many2one [id, name]) and sample parts per index",
+    )
+
+
+class KpiOdooConfigStatus(BaseModel):
+    """Odoo KPI config status for non-admin users (no request body)."""
+
+    kpi_id: int
+    configured: bool

--- a/backend/app/odoo/__init__.py
+++ b/backend/app/odoo/__init__.py
@@ -1,0 +1,1 @@
+"""Odoo KPI import integration."""

--- a/backend/app/odoo/config_service.py
+++ b/backend/app/odoo/config_service.py
@@ -1,0 +1,79 @@
+"""Odoo configuration persistence."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.models import OrganizationOdooConfig, KpiOdooConfig, KPI
+
+
+async def get_org_odoo_config(db: AsyncSession, org_id: int) -> OrganizationOdooConfig | None:
+    result = await db.execute(
+        select(OrganizationOdooConfig).where(OrganizationOdooConfig.organization_id == org_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_org_odoo_config(
+    db: AsyncSession,
+    org_id: int,
+    login_url: str,
+    data_fetch_url: str,
+    odoo_db: str | None,
+    username: str,
+    password: str,
+) -> OrganizationOdooConfig:
+    cfg = await get_org_odoo_config(db, org_id)
+    if cfg is None:
+        cfg = OrganizationOdooConfig(
+            organization_id=org_id,
+            login_url=login_url,
+            data_fetch_url=data_fetch_url,
+            odoo_db=odoo_db,
+            username=username,
+            password=password,
+        )
+        db.add(cfg)
+    else:
+        cfg.login_url = login_url
+        cfg.data_fetch_url = data_fetch_url
+        cfg.odoo_db = odoo_db
+        cfg.username = username
+        if password and password != "***":
+            cfg.password = password
+    await db.flush()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def get_kpi_odoo_config(db: AsyncSession, kpi_id: int) -> KpiOdooConfig | None:
+    result = await db.execute(select(KpiOdooConfig).where(KpiOdooConfig.kpi_id == kpi_id))
+    return result.scalar_one_or_none()
+
+
+async def upsert_kpi_odoo_config(
+    db: AsyncSession,
+    kpi_id: int,
+    request_body: dict | list,
+    response_items_path: str | None,
+) -> KpiOdooConfig:
+    cfg = await get_kpi_odoo_config(db, kpi_id)
+    if cfg is None:
+        cfg = KpiOdooConfig(
+            kpi_id=kpi_id,
+            request_body=request_body,
+            response_items_path=response_items_path,
+        )
+        db.add(cfg)
+    else:
+        cfg.request_body = request_body
+        cfg.response_items_path = response_items_path
+    await db.flush()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def kpi_belongs_to_org(db: AsyncSession, kpi_id: int, org_id: int) -> bool:
+    result = await db.execute(select(KPI.id).where(KPI.id == kpi_id, KPI.organization_id == org_id))
+    return result.scalar_one_or_none() is not None

--- a/backend/app/odoo/service.py
+++ b/backend/app/odoo/service.py
@@ -1,0 +1,371 @@
+"""Odoo XML-RPC/API authentication and KPI data fetch."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from typing import Any
+
+import httpx
+
+from app.core.models import OrganizationOdooConfig, KpiOdooConfig
+
+PLACEHOLDER_PATTERN = re.compile(
+    r"__([A-Z_]+)__"
+)
+
+SENSITIVE_FIELD_CONFIG_KEYS = frozenset(
+    {
+        "odoo_field_mappings",
+        "odoo_field_list_indices",
+        "multi_items_api_endpoint_url",
+    }
+)
+
+
+def mask_odoo_password(password: str | None) -> str:
+    if not password:
+        return ""
+    return "***"
+
+
+def sanitize_multi_items_field_config(config: dict | None, is_org_admin: bool) -> dict | None:
+    """Strip sensitive import config for non-admin users."""
+    if not config or is_org_admin:
+        return config
+    out = dict(config)
+    for key in SENSITIVE_FIELD_CONFIG_KEYS:
+        out.pop(key, None)
+    channel = out.get("multi_items_import_channel")
+    if channel == "odoo":
+        out["multi_items_import_channel"] = "odoo"
+    elif channel == "api":
+        out["multi_items_import_channel"] = "api"
+    return out
+
+
+def _replace_placeholders_in_str(value: str, context: dict[str, Any]) -> str:
+    def repl(m: re.Match) -> str:
+        key = m.group(1).lower()
+        if key in context:
+            return str(context[key])
+        return m.group(0)
+
+    return PLACEHOLDER_PATTERN.sub(repl, value)
+
+
+def _inject_context(obj: Any, context: dict[str, Any]) -> Any:
+    if isinstance(obj, str):
+        return _replace_placeholders_in_str(obj, context)
+    if isinstance(obj, list):
+        return [_inject_context(x, context) for x in obj]
+    if isinstance(obj, dict):
+        return {k: _inject_context(v, context) for k, v in obj.items()}
+    return obj
+
+
+def build_odoo_request_body(template: dict | list | Any, context: dict[str, Any]) -> Any:
+    """Deep-copy template and replace __SESSION_ID__, __YEAR__, etc."""
+    body = copy.deepcopy(template)
+    return _inject_context(body, context)
+
+
+def _extract_session_id(data: dict, cookies: httpx.Cookies) -> str | None:
+    result = data.get("result")
+    if isinstance(result, dict):
+        for key in ("session_id", "sid"):
+            val = result.get(key)
+            if val:
+                return str(val)
+        session = result.get("session")
+        if isinstance(session, dict) and session.get("sid"):
+            return str(session["sid"])
+        if result.get("uid"):
+            cookie_sid = cookies.get("session_id")
+            if cookie_sid:
+                return str(cookie_sid)
+    cookie_sid = cookies.get("session_id")
+    if cookie_sid:
+        return str(cookie_sid)
+    return None
+
+
+async def odoo_authenticate(cfg: OrganizationOdooConfig) -> str:
+    """Authenticate with Odoo login URL; return session id for the fetch step."""
+    db_name = (cfg.odoo_db or "").strip() or "OBE"
+    payload = {
+        "jsonrpc": "2.0",
+        "params": {
+            "db": db_name,
+            "login": cfg.username,
+            "password": cfg.password,
+        },
+        "id": None,
+    }
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(cfg.login_url, json=payload)
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise ValueError(f"Odoo login failed (HTTP {resp.status_code})")
+    try:
+        data = resp.json()
+    except Exception as e:
+        raise ValueError(f"Odoo login returned non-JSON response: {e}") from e
+    if data.get("error"):
+        raise ValueError(f"Odoo login error: {data.get('error')}")
+    session_id = _extract_session_id(data, resp.cookies)
+    if not session_id:
+        result = data.get("result")
+        uid = None
+        if isinstance(result, dict):
+            uc = result.get("user_context") or {}
+            uid = uc.get("uid") or result.get("uid")
+        if uid:
+            session_id = str(uid)
+        else:
+            raise ValueError("Odoo login succeeded but no session id was returned")
+    return session_id
+
+
+def _get_by_path(data: Any, path: str | None) -> Any:
+    if path is None or path.strip() == "":
+        for candidate in ("items", "data", "records", "rows"):
+            if isinstance(data, dict) and candidate in data:
+                return data[candidate]
+        if isinstance(data, dict) and "result" in data:
+            res = data["result"]
+            if isinstance(res, list):
+                return res
+            if isinstance(res, dict):
+                for candidate in ("items", "data", "records", "rows"):
+                    if candidate in res:
+                        return res[candidate]
+        return None
+    cur = data
+    for part in path.strip().split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+async def odoo_fetch_items(
+    cfg: OrganizationOdooConfig,
+    kpi_cfg: KpiOdooConfig,
+    session_id: str,
+    context: dict[str, Any],
+) -> list[dict]:
+    """Call data fetch URL with session and KPI request body; return list of row dicts."""
+    ctx = {
+        "session_id": session_id,
+        "year": context.get("year"),
+        "kpi_id": context.get("kpi_id"),
+        "organization_id": context.get("organization_id"),
+        "entry_id": context.get("entry_id"),
+        "field_id": context.get("field_id"),
+        "field_key": context.get("field_key"),
+    }
+    body = build_odoo_request_body(kpi_cfg.request_body, ctx)
+    if isinstance(body, dict) and "session_id" not in body and "__SESSION_ID__" not in json.dumps(kpi_cfg.request_body):
+        body["session_id"] = session_id
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    cookies = {"session_id": session_id}
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(
+            cfg.data_fetch_url,
+            json=body if isinstance(body, (dict, list)) else {"payload": body},
+            headers=headers,
+            cookies=cookies,
+        )
+    if resp.status_code < 200 or resp.status_code >= 300:
+        raise ValueError(f"Odoo data fetch failed (HTTP {resp.status_code})")
+    try:
+        data = resp.json()
+    except Exception as e:
+        raise ValueError(f"Odoo data fetch returned non-JSON: {e}") from e
+    if isinstance(data, dict) and data.get("error"):
+        raise ValueError(f"Odoo data fetch error: {data.get('error')}")
+
+    raw_items = _get_by_path(data, kpi_cfg.response_items_path)
+    if raw_items is None and isinstance(data, list):
+        raw_items = data
+    if not isinstance(raw_items, list):
+        raise ValueError("Odoo response did not contain a list of items")
+    items = [dict(x) for x in raw_items if isinstance(x, dict)]
+    return items
+
+
+def extract_odoo_columns(items: list[dict]) -> list[str]:
+    """Stable union of keys across all rows (first-seen order)."""
+    columns: list[str] = []
+    seen: set[str] = set()
+    for row in items:
+        for key in row.keys():
+            if key not in seen:
+                seen.add(key)
+                columns.append(str(key))
+    return columns
+
+
+def format_preview_cell(value: Any, max_len: int = 80) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    else:
+        text = str(value)
+    if len(text) > max_len:
+        return text[: max_len - 1] + "…"
+    return text
+
+
+def build_odoo_preview_rows(
+    items: list[dict],
+    columns: list[str],
+    *,
+    max_rows: int = 5,
+    max_columns: int = 7,
+) -> tuple[list[dict[str, str]], int]:
+    """Return display-safe sample rows using up to max_columns and max_rows."""
+    preview_cols = columns[:max_columns]
+    rows: list[dict[str, str]] = []
+    for row in items[:max_rows]:
+        rows.append({col: format_preview_cell(row.get(col)) for col in preview_cols})
+    return rows, len(preview_cols)
+
+
+def detect_odoo_list_columns(
+    items: list[dict],
+    columns: list[str],
+    *,
+    scan_rows: int = 25,
+) -> dict[str, list[dict[str, Any]]]:
+    """For columns whose values are list/tuple (e.g. Odoo many2one [id, name]), return index options with samples."""
+    out: dict[str, list[dict[str, Any]]] = {}
+    for col in columns:
+        sample_val: list | tuple | None = None
+        max_len = 0
+        for row in items[:scan_rows]:
+            val = row.get(col)
+            if not isinstance(val, (list, tuple)) or len(val) == 0:
+                continue
+            max_len = max(max_len, len(val))
+            if sample_val is None:
+                sample_val = val
+        if max_len == 0 or sample_val is None:
+            continue
+        parts: list[dict[str, Any]] = []
+        for i in range(max_len):
+            part = sample_val[i] if i < len(sample_val) else None
+            parts.append({"index": i, "sample": format_preview_cell(part, max_len=60)})
+        out[col] = parts
+    return out
+
+
+def serialize_odoo_cell_for_xlsx(value: Any) -> Any:
+    """Make Odoo cell values safe for openpyxl (lists/dicts as JSON text)."""
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, default=str)
+    return value
+
+
+def build_odoo_sample_xlsx_bytes(items: list[dict], columns: list[str]) -> bytes:
+    """Build an Excel workbook with all Odoo columns and rows (Super Admin sample export)."""
+    from io import BytesIO
+
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Odoo sample"
+    ws.append(list(columns))
+    for row in items:
+        ws.append([serialize_odoo_cell_for_xlsx(row.get(col)) for col in columns])
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def extract_odoo_mapped_value(value: Any, list_index: int | None) -> Any:
+    """Pick one element when Odoo returns a list/tuple (e.g. many2one [id, display_name])."""
+    if list_index is None:
+        return value
+    if not isinstance(value, (list, tuple)):
+        return value
+    if 0 <= list_index < len(value):
+        return value[list_index]
+    return value
+
+
+def apply_odoo_field_mappings(
+    items: list[dict],
+    mappings: dict[str, str],
+    valid_sub_keys: set[str],
+    list_indices: dict[str, int] | None = None,
+) -> list[dict]:
+    """Map Odoo field names to KPI multi-line sub-field keys."""
+    if not mappings:
+        return items
+    indices = list_indices or {}
+    out: list[dict] = []
+    for row in items:
+        mapped: dict[str, Any] = {}
+        for odoo_key, kpi_key in mappings.items():
+            if odoo_key in row and kpi_key in valid_sub_keys:
+                idx = indices.get(odoo_key)
+                mapped[kpi_key] = extract_odoo_mapped_value(row[odoo_key], idx)
+        for k, v in row.items():
+            if k in valid_sub_keys and k not in mapped:
+                mapped[k] = v
+        out.append(mapped)
+    return out
+
+
+def apply_odoo_sub_field_mappings(
+    items: list[dict],
+    sub_mappings: dict[str, dict[str, Any]],
+    valid_sub_keys: set[str],
+) -> list[dict]:
+    """
+    v2 mapping format: per KPI sub-field mapping to an Odoo column (and optional list index).
+
+    Allows mapping the same Odoo column to multiple KPI sub-fields (e.g. department_id[0] -> dept_id, department_id[1] -> dept_name_text).
+    sub_mappings example:
+      {
+        "dept_name_text": {"column": "department_id", "list_index": 1},
+        "dept_ref": {"column": "department_id", "list_index": 0},
+      }
+    """
+    if not sub_mappings:
+        return items
+    out: list[dict] = []
+    for row in items:
+        mapped: dict[str, Any] = {}
+        for sub_key, spec in sub_mappings.items():
+            if sub_key not in valid_sub_keys:
+                continue
+            if not isinstance(spec, dict):
+                continue
+            col = spec.get("column")
+            if not col or not isinstance(col, str):
+                continue
+            if col not in row:
+                continue
+            idx_raw = spec.get("list_index")
+            idx: int | None
+            if isinstance(idx_raw, int):
+                idx = idx_raw
+            elif isinstance(idx_raw, str) and idx_raw.isdigit():
+                idx = int(idx_raw)
+            else:
+                idx = None
+            mapped[sub_key] = extract_odoo_mapped_value(row[col], idx)
+        for k, v in row.items():
+            if k in valid_sub_keys and k not in mapped:
+                mapped[k] = v
+        out.append(mapped)
+    return out

--- a/backend/app/organizations/routes.py
+++ b/backend/app/organizations/routes.py
@@ -17,6 +17,8 @@ from app.organizations.schemas import (
     ExportTokenResponse,
     StorageConfigUpdate,
     StorageConfigResponse,
+    OdooConfigUpdate,
+    OdooConfigResponse,
     STORAGE_TYPES,
     mask_storage_params,
     OrganizationRoleCreate,
@@ -268,6 +270,102 @@ async def update_org_storage_config(
         organization_id=config.organization_id,
         storage_type=config.storage_type,
         params=mask_storage_params(config.params),
+        created_at=config.created_at.isoformat() + "Z" if config.created_at else None,
+        updated_at=config.updated_at.isoformat() + "Z" if config.updated_at else None,
+    )
+
+
+# --- Odoo config (Super Admin) ---
+
+
+@router.get("/{org_id}/odoo-config", response_model=OdooConfigResponse)
+async def get_org_odoo_config(
+    org_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Get organization Odoo connection settings (Super Admin only). Password is masked."""
+    from app.odoo.config_service import get_org_odoo_config as load_cfg
+
+    org = await get_organization(db, org_id)
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    config = await load_cfg(db, org_id)
+    if not config:
+        return OdooConfigResponse(organization_id=org_id, configured=False)
+    return OdooConfigResponse(
+        organization_id=config.organization_id,
+        configured=True,
+        login_url=config.login_url,
+        data_fetch_url=config.data_fetch_url,
+        odoo_db=config.odoo_db,
+        username=config.username,
+        password="***",
+        created_at=config.created_at.isoformat() + "Z" if config.created_at else None,
+        updated_at=config.updated_at.isoformat() + "Z" if config.updated_at else None,
+    )
+
+
+@router.get("/{org_id}/odoo-config/status")
+async def get_org_odoo_config_status(
+    org_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_org_admin_for_org),
+):
+    """Whether organization Odoo connection exists (no credentials exposed). Org Admin or Super Admin."""
+    from app.odoo.config_service import get_org_odoo_config as load_cfg
+
+    org = await get_organization(db, org_id)
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    config = await load_cfg(db, org_id)
+    return {"organization_id": org_id, "configured": config is not None}
+
+
+@router.patch("/{org_id}/odoo-config", response_model=OdooConfigResponse)
+async def update_org_odoo_config(
+    org_id: int,
+    body: OdooConfigUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_super_admin),
+):
+    """Create or update organization Odoo settings (Super Admin only)."""
+    from app.odoo.config_service import get_org_odoo_config as load_cfg, upsert_org_odoo_config
+
+    org = await get_organization(db, org_id)
+    if not org:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    existing = await load_cfg(db, org_id)
+    raw_password = (body.password or "").strip()
+    if existing is None:
+        if not raw_password or raw_password == "***":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Password is required when saving Odoo settings for the first time",
+            )
+        password = raw_password
+    elif raw_password and raw_password != "***":
+        password = raw_password
+    else:
+        password = existing.password
+    config = await upsert_org_odoo_config(
+        db,
+        org_id,
+        body.login_url.strip(),
+        body.data_fetch_url.strip(),
+        (body.odoo_db or "").strip() or None,
+        body.username.strip(),
+        password,
+    )
+    await db.commit()
+    return OdooConfigResponse(
+        organization_id=config.organization_id,
+        configured=True,
+        login_url=config.login_url,
+        data_fetch_url=config.data_fetch_url,
+        odoo_db=config.odoo_db,
+        username=config.username,
+        password="***",
         created_at=config.created_at.isoformat() + "Z" if config.created_at else None,
         updated_at=config.updated_at.isoformat() + "Z" if config.updated_at else None,
     )

--- a/backend/app/organizations/schemas.py
+++ b/backend/app/organizations/schemas.py
@@ -67,6 +67,37 @@ class ExportTokenResponse(BaseModel):
 
 STORAGE_TYPES = ("local", "gcs", "ftp", "s3", "onedrive")
 
+# --- Odoo config (Super Admin, per organization) ---
+
+
+class OdooConfigUpdate(BaseModel):
+    """Create or update organization Odoo connection."""
+
+    login_url: str = Field(..., min_length=1, max_length=2048)
+    data_fetch_url: str = Field(..., min_length=1, max_length=2048)
+    odoo_db: str | None = Field(None, max_length=255, description="Odoo database name for login")
+    username: str = Field(..., min_length=1, max_length=255)
+    password: str | None = Field(
+        None,
+        max_length=512,
+        description="Required on first save. Omit or send *** on update to keep existing password.",
+    )
+
+
+class OdooConfigResponse(BaseModel):
+    """Odoo config (password masked)."""
+
+    organization_id: int
+    configured: bool
+    login_url: str | None = None
+    data_fetch_url: str | None = None
+    odoo_db: str | None = None
+    username: str | None = None
+    password: str = Field(default="***", description="Masked")
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
 # Keys that must be masked in API responses (never log or return raw)
 STORAGE_SECRET_KEYS = frozenset(
     {"password", "secret", "credentials_path", "secret_access_key", "access_key_id", "token", "credentials"}

--- a/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
+++ b/frontend/src/app/dashboard/entries/[kpiId]/[year]/multi/[fieldId]/page.tsx
@@ -500,7 +500,15 @@ export default function FullPageMultiItems() {
   const [refFilterOptions, setRefFilterOptions] = useState<Record<string, string[]>>({});
   const [sourceKpiFieldsById, setSourceKpiFieldsById] = useState<Record<number, FieldSummary[]>>({});
   const [bulkPanelOpen, setBulkPanelOpen] = useState(false);
-  const [bulkChannel, setBulkChannel] = useState<"excel" | "api" | "previous_year" | null>(null);
+  const [bulkChannel, setBulkChannel] = useState<"excel" | "api" | "odoo" | "previous_year" | null>(null);
+  const [importCapabilities, setImportCapabilities] = useState<{
+    channels: string[];
+    odoo_ready: boolean;
+    odoo_org_configured?: boolean;
+    odoo_kpi_configured?: boolean;
+    odoo_blockers?: string[];
+    import_channel?: string;
+  } | null>(null);
   const [importFromYear, setImportFromYear] = useState<number>(() => {
     const y = new Date().getFullYear();
     return y - 1;
@@ -538,6 +546,7 @@ export default function FullPageMultiItems() {
   const entryIdLiveRef = useRef<number | null>(null);
 
   const isAdmin = userRole === "ORG_ADMIN" || userRole === "SUPER_ADMIN";
+  const isSuperAdmin = userRole === "SUPER_ADMIN";
   const canManageRowAccess = isAdmin;
   const canAddRowEffective = canAddRow || isAdmin;
 
@@ -605,6 +614,25 @@ export default function FullPageMultiItems() {
       .catch(() => setMeOrgId(null));
   }, [token]);
 
+  useEffect(() => {
+    if (!token || effectiveOrgId == null || !fieldId || !kpiId) return;
+    api<{ channels: string[]; odoo_ready: boolean; odoo_org_configured?: boolean; odoo_kpi_configured?: boolean; odoo_blockers?: string[]; import_channel?: string }>(
+      `/entries/multi-items/import-capabilities?${new URLSearchParams({
+        field_id: String(fieldId),
+        kpi_id: String(kpiId),
+        organization_id: String(effectiveOrgId),
+      }).toString()}`,
+      { token }
+    )
+      .then((c) => {
+        setImportCapabilities(c);
+        const ch = (field?.config as { multi_items_import_channel?: string } | undefined)?.multi_items_import_channel;
+        if (ch === "odoo" && c.odoo_ready) setBulkChannel("odoo");
+        else if (ch === "api") setBulkChannel("api");
+      })
+      .catch(() => setImportCapabilities(null));
+  }, [token, effectiveOrgId, fieldId, kpiId, field?.config]);
+
   const loadContext = async () => {
     if (!token || !kpiId || effectiveOrgId == null || !fieldId) return;
     const loadId = ++multiPageContextLoadGenRef.current;
@@ -646,7 +674,7 @@ export default function FullPageMultiItems() {
     }
   };
 
-  const loadRows = async () => {
+  const loadRows = async (opts?: { force?: boolean }) => {
     if (!token || !entryId || !fieldId || effectiveOrgId == null) return;
     const entryIdForThisFetch = entryId;
     const buildRowsQueryParams = (targetPage: number) => {
@@ -669,7 +697,7 @@ export default function FullPageMultiItems() {
 
     const cacheKey = buildRowsQueryParams(page).toString();
     const cached = rowsCacheRef.current.get(cacheKey);
-    if (cached) {
+    if (!opts?.force && cached) {
       setRows(cached.rows);
       setTotal(cached.total);
       setLoading(false);
@@ -721,6 +749,11 @@ export default function FullPageMultiItems() {
         setLoading(false);
       }
     }
+  };
+
+  const refreshRows = async () => {
+    rowsCacheRef.current.clear();
+    await loadRows({ force: true });
   };
 
   useEffect(() => {
@@ -978,7 +1011,7 @@ export default function FullPageMultiItems() {
       );
       toast.success("Rows deleted");
       setSelectedIndices([]);
-      await loadRows();
+      await refreshRows();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Bulk delete failed");
     }
@@ -1019,6 +1052,9 @@ export default function FullPageMultiItems() {
   }, [bulkChannel, token, effectiveOrgId, entryId, fieldId, kpiId, year, periodKey]);
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const uploadModeReady =
+    uploadOption != null && (uploadOption !== "upsert" || upsertMatchSubFieldKey.trim().length > 0);
 
   const openRowAccessModal = (row: MultiItemsRow) => {
     if (!token || !entryId || !fieldId || !kpiId || effectiveOrgId == null) return;
@@ -1975,10 +2011,42 @@ export default function FullPageMultiItems() {
                         setApiUrlOverride((field.config as any).multi_items_api_endpoint_url as string);
                       }
                     }}
-                    disabled={!entryId}
+                    disabled={!entryId || !(importCapabilities?.channels || []).includes("api")}
                   />
                   API
                 </label>
+                <label style={{ display: "flex", alignItems: "center", gap: "0.4rem", cursor: "pointer" }}>
+                  <input
+                    type="radio"
+                    name="uploadChannel"
+                    checked={bulkChannel === "odoo"}
+                    onChange={() => setBulkChannel("odoo")}
+                    disabled={!entryId || !importCapabilities?.odoo_ready}
+                  />
+                  Odoo
+                </label>
+                {!importCapabilities?.odoo_ready && (
+                  <p style={{ margin: "0.35rem 0 0", fontSize: "0.8rem", color: "var(--muted)", maxWidth: 520 }}>
+                    {!entryId
+                      ? "Create or open this year’s KPI entry first."
+                      : isSuperAdmin
+                        ? (importCapabilities?.odoo_blockers || []).join(" ") ||
+                          "Odoo is not ready: organization connection and KPI request body must both be configured."
+                        : (importCapabilities?.odoo_blockers || []).join(" ") ||
+                          "Odoo is not configured for this KPI. Ask your Super Admin to configure it first."}
+                    {entryId && effectiveOrgId != null && isSuperAdmin && (
+                      <>
+                        {" "}
+                        <Link
+                          href={`/dashboard/kpis/${kpiId}/fields?organization_id=${effectiveOrgId}&tab=odoo`}
+                          style={{ color: "var(--primary)", fontWeight: 500 }}
+                        >
+                          Configure Odoo on KPI Fields page →
+                        </Link>
+                      </>
+                    )}
+                  </p>
+                )}
                 <label style={{ display: "flex", alignItems: "center", gap: "0.4rem", cursor: "pointer" }}>
                   <input
                     type="radio"
@@ -2142,7 +2210,7 @@ export default function FullPageMultiItems() {
                                 : `${modeLabel}: ${added} rows imported${timeSuffix}`
                             );
                           }
-                          await loadRows();
+                          await refreshRows();
                           setBulkPanelOpen(false);
                           setUploadOption(null);
                         } else {
@@ -2304,7 +2372,7 @@ export default function FullPageMultiItems() {
                               : "API sync completed (no records imported)."
                           );
                         }
-                        await loadRows();
+                        await refreshRows();
                       } catch (e) {
                         toast.error(e instanceof Error ? e.message : "API sync failed");
                       }
@@ -2414,6 +2482,70 @@ export default function FullPageMultiItems() {
             </div>
           )}
 
+          {bulkChannel === "odoo" && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+              <p style={{ margin: 0, fontSize: "0.85rem", color: "var(--muted)" }}>
+                {isSuperAdmin
+                  ? "Loads data from Odoo using organization connection and KPI request body configured on the KPI Fields page."
+                  : "Loads data from Odoo using settings configured by your Super Admin."}
+              </p>
+              {!uploadModeReady && (
+                <p style={{ margin: 0, fontSize: "0.8rem", color: "var(--muted)" }}>
+                  Select an upload mode in Step 1 (Append, Override, or Update or add) to enable Odoo import.
+                </p>
+              )}
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!entryId || !uploadModeReady || uploading}
+                style={{
+                  alignSelf: "flex-start",
+                  opacity: entryId && uploadModeReady && !uploading ? 1 : 0.55,
+                  cursor: entryId && uploadModeReady && !uploading ? "pointer" : "not-allowed",
+                }}
+                onClick={async () => {
+                  if (!token || !entryId || !fieldId || effectiveOrgId == null || !uploadModeReady || !uploadOption) return;
+                  if (uploadOption === "upsert" && !upsertMatchSubFieldKey.trim()) {
+                    toast.error("Select which sub-field to use for matching.");
+                    return;
+                  }
+                  setUploading(true);
+                  try {
+                    const params = new URLSearchParams({
+                      entry_id: String(entryId),
+                      field_id: String(fieldId),
+                      organization_id: String(effectiveOrgId),
+                      sync_mode: uploadOption,
+                    });
+                    if (uploadOption === "upsert") {
+                      params.set("match_sub_field_key", upsertMatchSubFieldKey.trim());
+                    }
+                    const res = await api<{
+                      rows_imported?: number;
+                      rows_updated?: number;
+                      rows_appended?: number;
+                    }>(`/entries/multi-items/sync-from-odoo?${params.toString()}`, { method: "POST", token });
+                    if (uploadOption === "upsert") {
+                      toast.success(
+                        `Update or add: ${res?.rows_updated ?? 0} row(s) updated, ${res?.rows_appended ?? 0} new row(s) added`
+                      );
+                    } else {
+                      const n = res?.rows_imported ?? 0;
+                      toast.success(n > 0 ? `Imported ${n} record(s) from Odoo.` : "Odoo sync completed (no records imported).");
+                    }
+                    await refreshRows();
+                  } catch (e) {
+                    toast.error(e instanceof Error ? e.message : "Odoo sync failed");
+                  } finally {
+                    setUploading(false);
+                  }
+                }}
+              >
+                {uploading ? "Loading from Odoo…" : "Load data from Odoo"}
+              </button>
+            </div>
+          )}
+
           {/* Import from previous year */}
           {bulkChannel === "previous_year" && (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem", alignItems: "flex-end", justifyContent: "space-between" }}>
@@ -2495,7 +2627,7 @@ export default function FullPageMultiItems() {
                       const label = uploadOption === "append" ? "Appended" : "Replaced";
                       toast.success(overridden > 0 ? `${label}: ${added} rows imported (overrode ${overridden} existing)` : `${label}: ${added} rows imported`);
                     }
-                    await loadRows();
+                    await refreshRows();
                     setBulkPanelOpen(false);
                     setUploadOption(null);
                   } catch (e) {

--- a/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
+++ b/frontend/src/app/dashboard/kpis/[id]/fields/page.tsx
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { getAccessToken, type UserRole } from "@/lib/auth";
 import { api } from "@/lib/api";
 import toast from "react-hot-toast";
+import { OdooMultiLineImportAdmin } from "@/components/OdooMultiLineImportConfig";
 
 function qs(params: Record<string, string | number | boolean | undefined>): string {
   return new URLSearchParams(
@@ -308,10 +309,12 @@ export default function KpiFieldsPage() {
   const [addModalCategorySearch, setAddModalCategorySearch] = useState("");
   const [addModalSelectedIds, setAddModalSelectedIds] = useState<number[]>([]);
   const [addModalSelectedDomainIds, setAddModalSelectedDomainIds] = useState<number[]>([]);
-  type EditTabId = "details" | "fields" | "settings";
+  type EditTabId = "details" | "fields" | "settings" | "odoo";
   const tabFromUrl = searchParams.get("tab") as EditTabId | null;
   const [activeEditTab, setActiveEditTab] = useState<EditTabId>(
-    tabFromUrl === "details" || tabFromUrl === "fields" || tabFromUrl === "settings" ? tabFromUrl : "details"
+    tabFromUrl === "details" || tabFromUrl === "fields" || tabFromUrl === "settings" || tabFromUrl === "odoo"
+      ? tabFromUrl
+      : "details"
   );
   const [settingsPanel, setSettingsPanel] = useState<"order" | "time_dimension" | "entry_mode" | "domain" | "tags" | "danger_zone" | null>(null);
   const [syncYear, setSyncYear] = useState<number>(() => new Date().getFullYear());
@@ -342,15 +345,24 @@ export default function KpiFieldsPage() {
   }, [userRole, multiLineFields]);
 
   useEffect(() => {
-    if (tabFromUrl === "details" || tabFromUrl === "fields" || tabFromUrl === "settings") {
+    if (tabFromUrl === "details" || tabFromUrl === "fields" || tabFromUrl === "settings" || tabFromUrl === "odoo") {
       setActiveEditTab(tabFromUrl);
     }
   }, [tabFromUrl]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || userRole !== "SUPER_ADMIN") return;
+    if (window.location.hash === "#odoo-bulk-import" || tabFromUrl === "odoo") {
+      setActiveEditTab("odoo");
+    }
+  }, [userRole, tabFromUrl]);
+
   const setEditTab = (tab: EditTabId) => {
     setActiveEditTab(tab);
-    if (orgIdFromUrl != null) {
+    const oid = orgIdFromUrl ?? kpi?.organization_id ?? kpiOrgId;
+    if (oid != null) {
       const params = new URLSearchParams(searchParams.toString());
+      params.set("organization_id", String(oid));
       params.set("tab", tab);
       router.replace(`/dashboard/kpis/${kpiId}/fields?${params.toString()}`, { scroll: false });
     }
@@ -898,7 +910,7 @@ export default function KpiFieldsPage() {
   if (!kpiId) return <p>Invalid KPI.</p>;
   if (loading && list.length === 0 && !kpi) return <p>Loading...</p>;
 
-  const isOrgContext = orgIdFromUrl != null && kpi != null;
+  const isOrgContext = kpi != null && (orgIdFromUrl != null || userRole === "ORG_ADMIN" || userRole === "SUPER_ADMIN");
 
   const buildMultiLineUpdateFromField = (field: any): UpdateFormData => ({
     name: String(field?.name ?? ""),
@@ -1020,6 +1032,17 @@ export default function KpiFieldsPage() {
             >
               Fields {list.length > 0 && <span style={{ marginLeft: "0.35rem", opacity: 0.8 }}>({list.length})</span>}
             </button>
+            {userRole === "SUPER_ADMIN" && (
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeEditTab === "odoo"}
+                style={tabButtonStyle(activeEditTab === "odoo")}
+                onClick={() => setEditTab("odoo")}
+              >
+                Odoo import
+              </button>
+            )}
             <button
               type="button"
               role="tab"
@@ -1497,6 +1520,29 @@ export default function KpiFieldsPage() {
             </div>
           </div>
         </div>
+      )}
+
+      {isOrgContext && userRole === "SUPER_ADMIN" && activeEditTab === "odoo" && orgId != null && token && (
+        <OdooMultiLineImportAdmin
+          kpiId={kpiId}
+          orgId={orgId}
+          token={token}
+          fieldId={
+            editingId ??
+            list.find((f) => f.field_type === "multi_line_items")?.id
+          }
+          subFields={
+            (list.find((f) => f.id === editingId) || list.find((f) => f.field_type === "multi_line_items"))?.sub_fields?.map((s) => ({
+              key: s.key,
+              name: s.name,
+              field_type: s.field_type,
+              config: s.config ?? null,
+            })) ?? []
+          }
+          fieldConfig={
+            (list.find((f) => f.id === editingId) || list.find((f) => f.field_type === "multi_line_items"))?.config as Record<string, unknown> | null
+          }
+        />
       )}
 
       {(!isOrgContext || activeEditTab === "fields") && (

--- a/frontend/src/app/dashboard/organizations/[id]/page.tsx
+++ b/frontend/src/app/dashboard/organizations/[id]/page.tsx
@@ -62,6 +62,7 @@ const WHERE_OPERATORS = [
 type TabId = "overview" | "domains" | "kpis" | "reports" | "settings";
 type SettingsSubId =
   | "storage"
+  | "odoo"
   | "external_auth"
   | "time_dimension"
   | "tags"
@@ -339,6 +340,7 @@ function ApiContractBlock({ contract }: { contract: ApiContract }) {
 const TAB_IDS: TabId[] = ["overview", "domains", "kpis", "reports", "settings"];
 const SETTINGS_SUB_IDS: SettingsSubId[] = [
   "storage",
+  "odoo",
   "external_auth",
   "time_dimension",
   "tags",
@@ -600,6 +602,10 @@ export default function OrganizationDetailPage() {
           loadOrg={loadOrg}
         />
       )}
+
+      {tab === "settings" && userRole === "ORG_ADMIN" && (
+        <OrgAdminSettingsPage orgId={orgId} token={token!} settingsSub={settingsSub} setSettingsSub={(sub) => { setSettingsSub(sub); updateUrl("settings", sub); }} />
+      )}
     </div>
   );
 }
@@ -724,8 +730,10 @@ function OrganizationOverviewCards({
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
         </svg>
       ),
-      lines: ["Storage, time dimension, tags.", `${summary.tagCount} tag${summary.tagCount !== 1 ? "s" : ""} configured.`],
-      onClick: () => updateUrl("settings", "storage"),
+      lines: userRole === "SUPER_ADMIN"
+        ? ["Storage, Odoo, time dimension, tags.", `${summary.tagCount} tag${summary.tagCount !== 1 ? "s" : ""} configured.`]
+        : ["Odoo bulk import status for your organization.", "Configuration is managed by a Super Admin."],
+      onClick: () => updateUrl("settings", userRole === "SUPER_ADMIN" ? "storage" : "odoo"),
     },
   ];
   return (
@@ -766,6 +774,7 @@ function OrganizationOverviewCards({
 
 const SETTINGS_SUB_LABELS: Record<SettingsSubId, string> = {
   storage: "Storage settings",
+  odoo: "Odoo integration",
   external_auth: "External authentication",
   time_dimension: "Time dimension",
   tags: "Tags settings",
@@ -879,6 +888,7 @@ function SettingsPage({
       </nav>
       <div className="card" style={{ padding: "1.25rem" }}>
         {settingsSub === "storage" && <StorageConfigSection orgId={orgId} token={token} />}
+        {settingsSub === "odoo" && <OdooConfigSection orgId={orgId} token={token} />}
         {settingsSub === "external_auth" && <ExternalAuthConfigSection token={token} />}
         {settingsSub === "time_dimension" && (
           <div>
@@ -938,6 +948,76 @@ function SettingsPage({
         {settingsSub === "api_export" && (
           <ApiExportContent orgId={orgId} token={token} />
         )}
+      </div>
+    </div>
+  );
+}
+
+/** Org Admin: read-only Odoo status + where to configure KPI request bodies (no super-admin endpoints). */
+function OrgAdminSettingsPage({
+  orgId,
+  token,
+  settingsSub,
+  setSettingsSub,
+}: {
+  orgId: number;
+  token: string;
+  settingsSub: SettingsSubId;
+  setSettingsSub: (s: SettingsSubId) => void;
+}) {
+  const orgAdminSubs: SettingsSubId[] = ["odoo"];
+  const [orgOdooConfigured, setOrgOdooConfigured] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    api<{ configured: boolean }>(`/organizations/${orgId}/odoo-config/status`, { token })
+      .then((s) => setOrgOdooConfigured(s.configured))
+      .catch(() => setOrgOdooConfigured(false));
+  }, [orgId, token]);
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: "1.5rem", alignItems: "start" }}>
+      <nav className="card" style={{ padding: "0.5rem 0" }}>
+        {orgAdminSubs.map((sub) => (
+          <button
+            key={sub}
+            type="button"
+            onClick={() => setSettingsSub(sub)}
+            style={{
+              display: "block",
+              width: "100%",
+              padding: "0.6rem 1rem",
+              textAlign: "left",
+              border: "none",
+              background: settingsSub === sub ? "var(--accent-subtle, rgba(0,0,0,0.06))" : "transparent",
+              font: "inherit",
+              fontSize: "0.95rem",
+              color: settingsSub === sub ? "var(--accent)" : "var(--text)",
+              cursor: "pointer",
+              borderLeft: settingsSub === sub ? "3px solid var(--accent)" : "3px solid transparent",
+            }}
+          >
+            {SETTINGS_SUB_LABELS[sub]}
+          </button>
+        ))}
+      </nav>
+      <div className="card" style={{ padding: "1.25rem" }}>
+        <h2 style={{ fontSize: "1.1rem", marginBottom: "0.5rem" }}>Odoo bulk import</h2>
+        <p style={{ color: "var(--muted)", fontSize: "0.9rem", marginBottom: "1rem" }}>
+          Odoo connection and per-KPI import settings are managed by a Super Admin. You can use Odoo bulk import on
+          multi-line entry pages when setup is complete.
+        </p>
+        <p style={{ fontSize: "0.9rem", lineHeight: 1.6, margin: 0 }}>
+          <strong>Organization Odoo connection:</strong>{" "}
+          {orgOdooConfigured === null
+            ? "checking…"
+            : orgOdooConfigured
+              ? "configured"
+              : "not configured — contact your Super Admin"}
+        </p>
+        <p style={{ fontSize: "0.9rem", lineHeight: 1.6, margin: "0.75rem 0 0", color: "var(--muted)" }}>
+          Per-KPI request bodies and field mappings are not shown here. If Odoo import is unavailable on a field, open
+          that field&apos;s bulk upload panel for the current status message.
+        </p>
       </div>
     </div>
   );
@@ -1265,6 +1345,144 @@ const STORAGE_TYPES = [
   { value: "s3", label: "Amazon S3" },
   { value: "onedrive", label: "OneDrive" },
 ] as const;
+
+interface OdooConfigResponse {
+  organization_id: number;
+  configured: boolean;
+  login_url?: string | null;
+  data_fetch_url?: string | null;
+  odoo_db?: string | null;
+  username?: string | null;
+  password?: string;
+}
+
+function OdooConfigSection({ orgId, token }: { orgId: number; token: string }) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [configured, setConfigured] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    login_url: "",
+    data_fetch_url: "",
+    odoo_db: "",
+    username: "",
+    password: "",
+  });
+
+  const loadConfig = () => {
+    setLoading(true);
+    api<OdooConfigResponse>(`/organizations/${orgId}/odoo-config`, { token })
+      .then((c) => {
+        setConfigured(!!c.configured);
+        if (c.configured) {
+          setForm({
+            login_url: c.login_url || "",
+            data_fetch_url: c.data_fetch_url || "",
+            odoo_db: c.odoo_db || "",
+            username: c.username || "",
+            password: "",
+          });
+        }
+      })
+      .catch((err) => {
+        setConfigured(false);
+        setMessage(err instanceof Error ? err.message : "Failed to load Odoo settings");
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadConfig();
+  }, [orgId, token]);
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!configured && !form.password.trim()) {
+      setMessage("Password is required when saving Odoo settings for the first time.");
+      return;
+    }
+    setSaving(true);
+    setMessage(null);
+    const payload: Record<string, string | null> = {
+      login_url: form.login_url.trim(),
+      data_fetch_url: form.data_fetch_url.trim(),
+      odoo_db: form.odoo_db.trim() || null,
+      username: form.username.trim(),
+    };
+    if (form.password.trim()) {
+      payload.password = form.password.trim();
+    }
+    api<OdooConfigResponse>(`/organizations/${orgId}/odoo-config`, {
+      method: "PATCH",
+      token,
+      body: JSON.stringify(payload),
+    })
+      .then((c) => {
+        setConfigured(!!c.configured);
+        setMessage(`Odoo settings saved for organization #${orgId}.`);
+        toast.success("Odoo settings saved");
+        loadConfig();
+      })
+      .catch((err) => {
+        const msg = err instanceof Error ? err.message : "Failed to save";
+        setMessage(msg);
+        toast.error(msg);
+      })
+      .finally(() => setSaving(false));
+  };
+
+  if (loading) return <p style={{ color: "var(--muted)" }}>Loading Odoo config…</p>;
+
+  return (
+    <div style={{ maxWidth: "36rem" }}>
+      <h2 style={{ fontSize: "1.1rem", marginBottom: "0.5rem" }}>Odoo connection</h2>
+      <p style={{ color: "var(--muted)", fontSize: "0.9rem", marginBottom: "0.5rem" }}>
+        Organization ID: <strong>{orgId}</strong>
+        {configured ? (
+          <span style={{ marginLeft: "0.75rem", color: "var(--accent, green)" }}>● Configured</span>
+        ) : (
+          <span style={{ marginLeft: "0.75rem", color: "var(--muted)" }}>○ Not configured yet</span>
+        )}
+      </p>
+      <p style={{ color: "var(--muted)", fontSize: "0.9rem", marginBottom: "1rem" }}>
+        Configure Odoo login and data fetch URLs for KPI multi-line bulk import. Credentials are used server-side only.
+      </p>
+      <form onSubmit={handleSave}>
+        <div className="form-group">
+          <label>Odoo login URL</label>
+          <input value={form.login_url} onChange={(e) => setForm((p) => ({ ...p, login_url: e.target.value }))} required style={{ width: "100%" }} />
+        </div>
+        <div className="form-group">
+          <label>Odoo data fetch URL</label>
+          <input value={form.data_fetch_url} onChange={(e) => setForm((p) => ({ ...p, data_fetch_url: e.target.value }))} required style={{ width: "100%" }} />
+        </div>
+        <div className="form-group">
+          <label>Odoo database (optional)</label>
+          <input value={form.odoo_db} onChange={(e) => setForm((p) => ({ ...p, odoo_db: e.target.value }))} style={{ width: "100%" }} />
+        </div>
+        <div className="form-group">
+          <label>Username</label>
+          <input value={form.username} onChange={(e) => setForm((p) => ({ ...p, username: e.target.value }))} required style={{ width: "100%" }} />
+        </div>
+        <div className="form-group">
+          <label>Password{!configured ? " *" : ""}</label>
+          <input
+            type="password"
+            value={form.password}
+            onChange={(e) => setForm((p) => ({ ...p, password: e.target.value }))}
+            placeholder={configured ? "Leave blank to keep existing password" : "Required on first save"}
+            required={!configured}
+            style={{ width: "100%" }}
+          />
+        </div>
+        {message && <p style={{ fontSize: "0.9rem", marginBottom: "0.75rem" }}>{message}</p>}
+        <button type="submit" className="btn btn-primary" disabled={saving}>
+          {saving ? "Saving…" : "Save Odoo settings"}
+        </button>
+      </form>
+    </div>
+  );
+}
 
 interface StorageConfigResponse {
   organization_id: number;

--- a/frontend/src/components/OdooMultiLineImportConfig.tsx
+++ b/frontend/src/components/OdooMultiLineImportConfig.tsx
@@ -1,0 +1,901 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { api, getApiUrl } from "@/lib/api";
+
+type ReferenceConfig = {
+  reference_source_kpi_id?: number;
+  reference_source_field_key?: string;
+  reference_source_sub_field_key?: string;
+};
+
+type SubField = {
+  key: string;
+  name: string;
+  field_type?: string;
+  config?: ReferenceConfig | Record<string, unknown> | null;
+};
+
+type OdooListColumnPart = {
+  index: number;
+  sample: string;
+};
+
+type OdooPreview = {
+  columns: string[];
+  sample_rows: Record<string, string>[];
+  total_rows: number;
+  preview_row_count: number;
+  preview_column_count: number;
+  list_columns?: Record<string, OdooListColumnPart[]>;
+};
+
+type KpiMeta = {
+  name: string;
+  categoryPath: string;
+};
+
+type FieldSummary = {
+  key: string;
+  name: string;
+  field_type: string;
+  sub_fields?: Array<{ key: string; name: string; field_type?: string }>;
+};
+
+function isReferenceLike(ft: string | undefined): boolean {
+  return ft === "reference" || ft === "multi_reference";
+}
+
+function buildKpiCategoryPath(tags?: Array<{ domain_name?: string | null; name: string }>): string {
+  if (!tags?.length) return "";
+  const c = tags[0];
+  return c.domain_name ? `${c.domain_name} → ${c.name}` : c.name;
+}
+
+function formatSourceFieldPath(fields: FieldSummary[], fieldKey: string, subFieldKey?: string): string {
+  const f = fields.find((x) => x.key === fieldKey);
+  if (!f) return fieldKey;
+  if (subFieldKey && f.field_type === "multi_line_items" && f.sub_fields?.length) {
+    const s = f.sub_fields.find((x) => x.key === subFieldKey);
+    return s ? `${f.name} → ${s.name}` : `${f.name} → ${subFieldKey}`;
+  }
+  return f.name || fieldKey;
+}
+
+function buildFullReferencePath(
+  kpiMeta: KpiMeta | undefined,
+  fields: FieldSummary[],
+  fieldKey: string,
+  subFieldKey?: string
+): string {
+  const kpiLabel = kpiMeta
+    ? kpiMeta.categoryPath
+      ? `${kpiMeta.categoryPath} → ${kpiMeta.name}`
+      : kpiMeta.name
+    : "Unknown KPI";
+  const fieldLabel = formatSourceFieldPath(fields, fieldKey, subFieldKey);
+  return `${kpiLabel} → ${fieldLabel}`;
+}
+
+function fieldTypeRequirementHint(fieldType: string | undefined): string {
+  switch (fieldType) {
+    case "number":
+      return "Numeric values (e.g. 42, 1500.5)";
+    case "date":
+      return "Date values (e.g. 2024-06-15)";
+    case "boolean":
+      return "Boolean: true or false";
+    case "reference":
+      return "Single text value that must exist in the linked KPI field below";
+    case "multi_reference":
+      return "One or more values (comma-separated) that must exist in the linked KPI field below";
+    case "single_line_text":
+      return "Short text";
+    case "multi_line_text":
+      return "Longer text";
+    default:
+      return fieldType ? fieldType.replace(/_/g, " ") : "Text or structured value";
+  }
+}
+
+function samplePreviewValues(preview: OdooPreview | null, column: string, limit = 4): string[] {
+  if (!preview || !column) return [];
+  const out: string[] = [];
+  for (const row of preview.sample_rows) {
+    const v = (row[column] ?? "").trim();
+    if (!v || out.includes(v)) continue;
+    out.push(v);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+const hintBlockStyle: React.CSSProperties = {
+  marginTop: "0.4rem",
+  fontSize: "0.78rem",
+  color: "var(--muted)",
+  lineHeight: 1.45,
+};
+
+/** Super Admin: KPI Odoo JSON request body + fetch preview + field mappings (channel always Odoo). */
+export function OdooMultiLineImportAdmin({
+  kpiId,
+  orgId,
+  token,
+  fieldId,
+  subFields,
+  fieldConfig,
+  onFieldConfigChange,
+}: {
+  kpiId: number;
+  orgId: number | null;
+  token: string;
+  fieldId?: number;
+  subFields?: SubField[];
+  fieldConfig?: Record<string, unknown> | null;
+  onFieldConfigChange?: (cfg: Record<string, unknown>) => void;
+}) {
+  const currentYear = new Date().getFullYear();
+  const [requestBodyText, setRequestBodyText] = useState('{\n  "jsonrpc": "2.0",\n  "params": {}\n}');
+  const [responsePath, setResponsePath] = useState("");
+  const [previewYear, setPreviewYear] = useState(currentYear);
+  const [savingKpi, setSavingKpi] = useState(false);
+  const [fetchingPreview, setFetchingPreview] = useState(false);
+  const [downloadingSample, setDownloadingSample] = useState(false);
+  const [savingMappings, setSavingMappings] = useState(false);
+  const [kpiConfigured, setKpiConfigured] = useState(false);
+  const [orgOdooConfigured, setOrgOdooConfigured] = useState<boolean | null>(null);
+  const [odooColumns, setOdooColumns] = useState<string[]>([]);
+  const [preview, setPreview] = useState<OdooPreview | null>(null);
+  const [mappingBySubKey, setMappingBySubKey] = useState<Record<string, string>>({});
+  const [listIndexBySubKey, setListIndexBySubKey] = useState<Record<string, number | "">>({});
+  const [kpiMetaById, setKpiMetaById] = useState<Record<number, KpiMeta>>({});
+  const [fieldsByKpiId, setFieldsByKpiId] = useState<Record<number, FieldSummary[]>>({});
+  const [refSamplesByKey, setRefSamplesByKey] = useState<Record<string, string[]>>({});
+
+  const oq = orgId != null ? `?organization_id=${orgId}` : "";
+  const hasMultiLineField = fieldId != null;
+  const subFieldList = subFields ?? [];
+
+  const previewTableColumns = useMemo(
+    () => (preview ? preview.columns.slice(0, preview.preview_column_count) : []),
+    [preview]
+  );
+
+  const unmappedOdooColumns = useMemo(() => {
+    const used = new Set(Object.values(mappingBySubKey).filter(Boolean));
+    return odooColumns.filter((c) => !used.has(c));
+  }, [odooColumns, mappingBySubKey]);
+
+  const listColumnPartsByOdooCol = useMemo(() => {
+    const src = preview?.list_columns ?? {};
+    return src;
+  }, [preview?.list_columns]);
+
+  const referenceSourceKpiIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const sf of subFieldList) {
+      if (!isReferenceLike(sf.field_type)) continue;
+      const cfg = (sf.config ?? {}) as ReferenceConfig;
+      if (cfg.reference_source_kpi_id) ids.add(cfg.reference_source_kpi_id);
+    }
+    return [...ids];
+  }, [subFieldList]);
+
+  const referenceSourceKpiSig = referenceSourceKpiIds.join(",");
+
+  const refSampleTargets = useMemo(() => {
+    const targets: Array<{ cacheKey: string; sid: number; skey: string; subkey?: string }> = [];
+    for (const sf of subFieldList) {
+      if (!isReferenceLike(sf.field_type)) continue;
+      const cfg = (sf.config ?? {}) as ReferenceConfig;
+      const sid = cfg.reference_source_kpi_id;
+      const skey = cfg.reference_source_field_key;
+      if (!sid || !skey) continue;
+      const subkey = cfg.reference_source_sub_field_key;
+      targets.push({
+        cacheKey: `${sid}-${skey}${subkey ? `-${subkey}` : ""}@${previewYear}`,
+        sid,
+        skey,
+        subkey,
+      });
+    }
+    return targets;
+  }, [subFieldList, previewYear]);
+
+  const refSampleTargetsSig = refSampleTargets.map((t) => t.cacheKey).join("|");
+
+  useEffect(() => {
+    if (typeof window === "undefined" || window.location.hash !== "#odoo-bulk-import") return;
+    const el = document.getElementById("odoo-bulk-import");
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  useEffect(() => {
+    if (!token || !kpiId) return;
+    api<{ configured: boolean; request_body?: unknown; response_items_path?: string | null }>(
+      `/kpis/${kpiId}/odoo-config${oq}`,
+      { token }
+    )
+      .then((c) => {
+        setKpiConfigured(!!c.configured);
+        if (c.configured && c.request_body != null) {
+          setRequestBodyText(JSON.stringify(c.request_body, null, 2));
+          setResponsePath(c.response_items_path || "");
+        }
+      })
+      .catch(() => setKpiConfigured(false));
+  }, [token, kpiId, oq]);
+
+  useEffect(() => {
+    if (!token || orgId == null) return;
+    api<{ configured: boolean }>(`/organizations/${orgId}/odoo-config/status`, { token })
+      .then((s) => setOrgOdooConfigured(s.configured))
+      .catch(() => setOrgOdooConfigured(false));
+  }, [token, orgId]);
+
+  const subFieldKeySig = useMemo(
+    () => subFieldList.map((s) => s.key).sort().join("|"),
+    [subFields]
+  );
+
+  useEffect(() => {
+    const list = subFields ?? [];
+    const m = fieldConfig?.odoo_field_mappings;
+    const li = fieldConfig?.odoo_field_list_indices;
+    const v2 = fieldConfig?.odoo_sub_field_mappings;
+    const next: Record<string, string> = {};
+    const nextListIdx: Record<string, number | ""> = {};
+    for (const sf of list) {
+      next[sf.key] = "";
+      nextListIdx[sf.key] = "";
+    }
+    if (v2 && typeof v2 === "object" && !Array.isArray(v2)) {
+      for (const [kpiKey, spec] of Object.entries(v2 as Record<string, { column?: string; list_index?: number | string }>)) {
+        if (!(kpiKey in next)) continue;
+        const col = spec?.column;
+        if (typeof col === "string") next[kpiKey] = col;
+        const idx = spec?.list_index;
+        const n = typeof idx === "number" ? idx : typeof idx === "string" ? Number(idx) : NaN;
+        if (Number.isInteger(n) && n >= 0) nextListIdx[kpiKey] = n;
+      }
+      setMappingBySubKey(next);
+      setListIndexBySubKey(nextListIdx);
+      return;
+    }
+    if (m && typeof m === "object" && !Array.isArray(m)) {
+      for (const [odoo, kpi] of Object.entries(m as Record<string, string>)) {
+        if (kpi && kpi in next) {
+          next[kpi] = odoo;
+        }
+      }
+    }
+    if (li && typeof li === "object" && !Array.isArray(li)) {
+      for (const [odooCol, idx] of Object.entries(li as Record<string, number | string>)) {
+        const kpiKey = Object.entries(next).find(([, col]) => col === odooCol)?.[0];
+        if (!kpiKey) continue;
+        const n = typeof idx === "number" ? idx : Number(idx);
+        if (Number.isInteger(n) && n >= 0) {
+          nextListIdx[kpiKey] = n;
+        }
+      }
+    }
+    setMappingBySubKey(next);
+    setListIndexBySubKey(nextListIdx);
+  }, [fieldConfig, subFieldKeySig]);
+
+  useEffect(() => {
+    if (!token || orgId == null || !referenceSourceKpiSig) return;
+    let cancelled = false;
+    for (const sourceKpiId of referenceSourceKpiIds) {
+      api<{
+        name: string;
+        category_tags?: Array<{ domain_name?: string | null; name: string }>;
+      }>(`/kpis/${sourceKpiId}?organization_id=${orgId}`, { token })
+        .then((kpi) => {
+          if (cancelled) return;
+          setKpiMetaById((prev) =>
+            prev[sourceKpiId]
+              ? prev
+              : {
+                  ...prev,
+                  [sourceKpiId]: { name: kpi.name, categoryPath: buildKpiCategoryPath(kpi.category_tags) },
+                }
+          );
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setKpiMetaById((prev) =>
+            prev[sourceKpiId]
+              ? prev
+              : { ...prev, [sourceKpiId]: { name: `KPI #${sourceKpiId}`, categoryPath: "" } }
+          );
+        });
+
+      api<FieldSummary[]>(`/fields?kpi_id=${sourceKpiId}&organization_id=${orgId}`, { token })
+        .then((list) => {
+          if (cancelled) return;
+          setFieldsByKpiId((prev) => (prev[sourceKpiId] ? prev : { ...prev, [sourceKpiId]: list }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setFieldsByKpiId((prev) => (prev[sourceKpiId] ? prev : { ...prev, [sourceKpiId]: [] }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [token, orgId, referenceSourceKpiSig, referenceSourceKpiIds]);
+
+  useEffect(() => {
+    if (!token || orgId == null || !refSampleTargetsSig) return;
+    let cancelled = false;
+    for (const t of refSampleTargets) {
+      const params = new URLSearchParams({
+        source_kpi_id: String(t.sid),
+        source_field_key: t.skey,
+        organization_id: String(orgId),
+        year: String(previewYear),
+      });
+      if (t.subkey) params.set("source_sub_field_key", t.subkey);
+      api<{ values: string[] }>(`/fields/reference-allowed-values?${params.toString()}`, { token })
+        .then((r) => {
+          if (cancelled) return;
+          setRefSamplesByKey((prev) =>
+            prev[t.cacheKey] !== undefined
+              ? prev
+              : { ...prev, [t.cacheKey]: (r.values || []).slice(0, 8) }
+          );
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setRefSamplesByKey((prev) => (prev[t.cacheKey] !== undefined ? prev : { ...prev, [t.cacheKey]: [] }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [token, orgId, previewYear, refSampleTargetsSig, refSampleTargets]);
+
+  function suggestMappings(columns: string[], base: Record<string, string>): Record<string, string> {
+    const next = { ...base };
+    for (const sf of subFieldList) {
+      if (next[sf.key]) continue;
+      const byKey = columns.find((c) => c.toLowerCase() === sf.key.toLowerCase());
+      if (byKey) {
+        next[sf.key] = byKey;
+        continue;
+      }
+      const normalizedName = sf.name.toLowerCase().replace(/\s+/g, "_");
+      const byName = columns.find((c) => c.toLowerCase() === normalizedName);
+      if (byName) next[sf.key] = byName;
+    }
+    return next;
+  }
+
+  async function saveKpiBody(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingKpi(true);
+    try {
+      const request_body = JSON.parse(requestBodyText);
+      await api(`/kpis/${kpiId}/odoo-config${oq}`, {
+        method: "PUT",
+        token,
+        body: JSON.stringify({
+          request_body,
+          response_items_path: responsePath.trim() || null,
+        }),
+      });
+      toast.success("KPI Odoo request body saved");
+      setKpiConfigured(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Invalid JSON or save failed");
+    } finally {
+      setSavingKpi(false);
+    }
+  }
+
+  async function fetchOdooPreview() {
+    if (!fieldId || !token) return;
+    setFetchingPreview(true);
+    try {
+      let request_body: unknown | undefined;
+      try {
+        request_body = JSON.parse(requestBodyText);
+      } catch {
+        request_body = undefined;
+      }
+      const params = new URLSearchParams({
+        field_id: String(fieldId),
+        year: String(previewYear),
+      });
+      if (orgId != null) params.set("organization_id", String(orgId));
+
+      const body: Record<string, unknown> = {};
+      if (request_body !== undefined) {
+        body.request_body = request_body;
+        body.response_items_path = responsePath.trim() || null;
+      }
+
+      const result = await api<OdooPreview>(`/kpis/${kpiId}/odoo-preview?${params.toString()}`, {
+        method: "POST",
+        token,
+        body: JSON.stringify(body),
+      });
+      setPreview(result);
+      setOdooColumns(result.columns);
+      setMappingBySubKey((prev) => {
+        const next = suggestMappings(result.columns, prev);
+        const listCols = result.list_columns ?? {};
+        setListIndexBySubKey((prevIdx) => {
+          const idxNext = { ...prevIdx };
+          for (const sf of subFieldList) {
+            const col = next[sf.key];
+            const parts = col ? listCols[col] : undefined;
+            if (!parts?.length) {
+              idxNext[sf.key] = "";
+              continue;
+            }
+            const current = idxNext[sf.key];
+            if (current === "" || !parts.some((p) => p.index === current)) {
+              idxNext[sf.key] = parts[0].index;
+            }
+          }
+          return idxNext;
+        });
+        return next;
+      });
+      toast.success(`Fetched ${result.total_rows} row(s), ${result.columns.length} column(s)`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to fetch Odoo sample data");
+    } finally {
+      setFetchingPreview(false);
+    }
+  }
+
+  async function downloadOdooSampleExcel() {
+    if (!fieldId || !token || !preview) return;
+    setDownloadingSample(true);
+    try {
+      let request_body: unknown | undefined;
+      try {
+        request_body = JSON.parse(requestBodyText);
+      } catch {
+        request_body = undefined;
+      }
+      const params = new URLSearchParams({
+        field_id: String(fieldId),
+        year: String(previewYear),
+      });
+      if (orgId != null) params.set("organization_id", String(orgId));
+
+      const body: Record<string, unknown> = {};
+      if (request_body !== undefined) {
+        body.request_body = request_body;
+        body.response_items_path = responsePath.trim() || null;
+      }
+
+      const res = await fetch(getApiUrl(`/kpis/${kpiId}/odoo-preview-export?${params.toString()}`), {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        let detail = "Excel download failed";
+        try {
+          const err = await res.json();
+          if (err?.detail) detail = String(err.detail);
+        } catch {
+          /* ignore */
+        }
+        throw new Error(detail);
+      }
+      const blob = await res.blob();
+      const disposition = res.headers.get("Content-Disposition") || "";
+      const match = disposition.match(/filename="?([^";]+)"?/i);
+      const filename = match?.[1] || `odoo_sample_kpi${kpiId}_${previewYear}.xlsx`;
+      const a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(a.href);
+      toast.success("Odoo sample Excel downloaded");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Excel download failed");
+    } finally {
+      setDownloadingSample(false);
+    }
+  }
+
+  function setOdooColumnForSubField(subKey: string, odooCol: string) {
+    setMappingBySubKey((prev) => ({ ...prev, [subKey]: odooCol }));
+    const parts = odooCol ? listColumnPartsByOdooCol[odooCol] : undefined;
+    if (!parts?.length) {
+      setListIndexBySubKey((prev) => ({ ...prev, [subKey]: "" }));
+      return;
+    }
+    setListIndexBySubKey((prev) => {
+      const current = prev[subKey];
+      if (current !== "" && parts.some((p) => p.index === current)) {
+        return prev;
+      }
+      return { ...prev, [subKey]: parts[0].index };
+    });
+  }
+
+  async function saveFieldMappings() {
+    if (!fieldId || !token) return;
+    setSavingMappings(true);
+    try {
+      const odoo_field_mappings: Record<string, string> = {};
+      const odoo_field_list_indices: Record<string, number> = {};
+      const odoo_sub_field_mappings: Record<string, { column: string; list_index?: number }> = {};
+      for (const [kpiKey, odooCol] of Object.entries(mappingBySubKey)) {
+        const col = odooCol.trim();
+        if (!col) continue;
+        odoo_field_mappings[col] = kpiKey;
+        const parts = listColumnPartsByOdooCol[col];
+        const idx = listIndexBySubKey[kpiKey];
+        if (parts?.length && idx !== "" && typeof idx === "number") {
+          odoo_field_list_indices[col] = idx;
+        }
+        // v2: per-sub-field mapping (supports same Odoo column mapped to multiple sub-fields)
+        if (parts?.length && idx !== "" && typeof idx === "number") {
+          odoo_sub_field_mappings[kpiKey] = { column: col, list_index: idx };
+        } else {
+          odoo_sub_field_mappings[kpiKey] = { column: col };
+        }
+      }
+      const cfg = {
+        ...(fieldConfig || {}),
+        multi_items_import_channel: "odoo",
+        odoo_field_mappings,
+        odoo_field_list_indices,
+        odoo_sub_field_mappings,
+      };
+      onFieldConfigChange?.(cfg);
+      await api(`/fields/${fieldId}${oq}`, {
+        method: "PATCH",
+        token,
+        body: JSON.stringify({ config: cfg }),
+      });
+      toast.success("Odoo field mappings saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSavingMappings(false);
+    }
+  }
+
+  function renderSubFieldContext(sf: SubField) {
+    const cfg = (sf.config ?? {}) as ReferenceConfig;
+    const isRef = isReferenceLike(sf.field_type);
+    const sid = cfg.reference_source_kpi_id;
+    const skey = cfg.reference_source_field_key;
+    const subkey = cfg.reference_source_sub_field_key;
+    const cacheKey = sid && skey ? `${sid}-${skey}${subkey ? `-${subkey}` : ""}@${previewYear}` : "";
+    const refSamples = cacheKey ? refSamplesByKey[cacheKey] : undefined;
+
+    return (
+      <div style={hintBlockStyle}>
+        <div>
+          <span style={{ fontWeight: 500, color: "var(--text)" }}>Type:</span>{" "}
+          {fieldTypeRequirementHint(sf.field_type)}
+        </div>
+        {isRef && sid && skey && (
+          <div style={{ marginTop: "0.3rem" }}>
+            <span style={{ fontWeight: 500, color: "var(--text)" }}>Linked to:</span>{" "}
+            {buildFullReferencePath(
+              kpiMetaById[sid],
+              fieldsByKpiId[sid] ?? [],
+              skey,
+              subkey
+            )}
+          </div>
+        )}
+        {isRef && sid && skey && (
+          <div style={{ marginTop: "0.3rem" }}>
+            <span style={{ fontWeight: 500, color: "var(--text)" }}>Sample values from linked KPI</span>
+            {refSamples === undefined ? (
+              <span> (loading…)</span>
+            ) : refSamples.length > 0 ? (
+              <span>: {refSamples.join(", ")}</span>
+            ) : (
+              <span>: no values found for year {previewYear} — check that the source KPI has data</span>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  function renderOdooColumnContext(column: string) {
+    const samples = samplePreviewValues(preview, column);
+    if (!column) return null;
+    return (
+      <div style={hintBlockStyle}>
+        {samples.length > 0 ? (
+          <>
+            <span style={{ fontWeight: 500, color: "var(--text)" }}>Odoo sample data:</span> {samples.join(", ")}
+          </>
+        ) : (
+          <span>No sample values in preview for this column.</span>
+        )}
+      </div>
+    );
+  }
+
+  const canFetchPreview =
+    hasMultiLineField &&
+    orgOdooConfigured === true &&
+    (kpiConfigured || requestBodyText.trim().length > 0);
+
+  return (
+    <div id="odoo-bulk-import" className="card" style={{ padding: "1rem", marginBottom: "1rem" }}>
+      <h3 style={{ fontSize: "1rem", margin: "0 0 0.75rem" }}>Odoo bulk import (Super Admin)</h3>
+      <ul style={{ margin: "0 0 1rem", paddingLeft: "1.2rem", fontSize: "0.85rem", color: "var(--muted)" }}>
+        <li>
+          Organization Odoo connection:{" "}
+          {orgOdooConfigured === null
+            ? "…"
+            : orgOdooConfigured
+              ? "configured"
+              : "not configured — ask a Super Admin to set Organization → Settings → Odoo integration"}
+        </li>
+        <li>KPI request body: {kpiConfigured ? "saved" : "not saved yet — complete Step 1 below"}</li>
+        <li>Import channel for this field: <strong>Odoo</strong> (set automatically when mappings are saved)</li>
+      </ul>
+
+      <form onSubmit={saveKpiBody}>
+        <h4 style={{ fontSize: "0.9rem", margin: "0 0 0.35rem" }}>Step 1 — KPI Odoo request body</h4>
+        <p style={{ fontSize: "0.85rem", color: "var(--muted)", marginBottom: "0.5rem" }}>
+          JSON sent to your organization&apos;s Odoo data fetch URL. Placeholders: __SESSION_ID__, __YEAR__, __KPI_ID__,
+          __ORG_ID__, __ENTRY_ID__, __FIELD_ID__, __FIELD_KEY__.
+        </p>
+        <textarea
+          value={requestBodyText}
+          onChange={(e) => setRequestBodyText(e.target.value)}
+          rows={8}
+          style={{ width: "100%", fontFamily: "monospace", fontSize: "0.8rem" }}
+        />
+        <div className="form-group" style={{ marginTop: "0.5rem" }}>
+          <label>Response items path (optional, e.g. result.records)</label>
+          <input value={responsePath} onChange={(e) => setResponsePath(e.target.value)} style={{ width: "100%" }} />
+        </div>
+        <button type="submit" className="btn btn-primary" disabled={savingKpi} style={{ marginTop: "0.5rem" }}>
+          {savingKpi ? "Saving…" : "Save KPI Odoo request body"}
+        </button>
+      </form>
+
+      {hasMultiLineField ? (
+        <>
+          <div style={{ marginTop: "1.25rem", borderTop: "1px solid var(--border)", paddingTop: "1rem" }}>
+            <h4 style={{ fontSize: "0.9rem", margin: "0 0 0.35rem" }}>Step 2 — Fetch Odoo columns &amp; sample data</h4>
+            <p style={{ fontSize: "0.85rem", color: "var(--muted)", marginBottom: "0.75rem" }}>
+              Loads live data from Odoo using the request body above. The preview table shows up to 7 columns and 5 rows.
+            </p>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem", alignItems: "flex-end", marginBottom: "0.75rem" }}>
+              <div className="form-group" style={{ margin: 0 }}>
+                <label htmlFor="odoo-preview-year">Year (__YEAR__)</label>
+                <input
+                  id="odoo-preview-year"
+                  type="number"
+                  min={2000}
+                  max={2100}
+                  value={previewYear}
+                  onChange={(e) => setPreviewYear(Number(e.target.value) || currentYear)}
+                  style={{ width: "7rem" }}
+                />
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={!canFetchPreview || fetchingPreview}
+                onClick={fetchOdooPreview}
+              >
+                {fetchingPreview ? "Fetching…" : "Fetch sample data"}
+              </button>
+              {preview && (
+                <button
+                  type="button"
+                  className="btn"
+                  disabled={downloadingSample || fetchingPreview}
+                  onClick={downloadOdooSampleExcel}
+                >
+                  {downloadingSample ? "Downloading…" : "Download Excel (all columns)"}
+                </button>
+              )}
+            </div>
+
+            {preview && previewTableColumns.length > 0 && (
+              <div style={{ overflowX: "auto", marginBottom: "0.5rem" }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.8rem" }}>
+                  <thead>
+                    <tr>
+                      {previewTableColumns.map((col) => (
+                        <th
+                          key={col}
+                          style={{
+                            textAlign: "left",
+                            padding: "0.4rem 0.5rem",
+                            borderBottom: "1px solid var(--border)",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {col}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {preview.sample_rows.map((row, i) => (
+                      <tr key={i}>
+                        {previewTableColumns.map((col) => (
+                          <td
+                            key={col}
+                            style={{
+                              padding: "0.4rem 0.5rem",
+                              borderBottom: "1px solid var(--border)",
+                              maxWidth: 160,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                            title={row[col] ?? ""}
+                          >
+                            {row[col] ?? ""}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <p style={{ fontSize: "0.8rem", color: "var(--muted)", margin: "0.35rem 0 0" }}>
+                  {preview.total_rows} total row(s), {preview.columns.length} column(s).
+                  {preview.columns.length > preview.preview_column_count &&
+                    ` Showing first ${preview.preview_column_count} columns in preview.`}
+                  {" "}
+                  Use <strong>Download Excel (all columns)</strong> for the full dataset.
+                </p>
+              </div>
+            )}
+          </div>
+
+          {odooColumns.length > 0 && subFieldList.length > 0 && (
+            <div style={{ marginTop: "1.25rem", borderTop: "1px solid var(--border)", paddingTop: "1rem" }}>
+              <h4 style={{ fontSize: "0.9rem", margin: "0 0 0.35rem" }}>Step 3 — Map KPI sub-fields to Odoo columns</h4>
+              <p style={{ fontSize: "0.85rem", color: "var(--muted)", marginBottom: "0.75rem" }}>
+                Each row is one multi-line sub-field. Pick the Odoo column whose values match the expected data type and
+                linked KPI (for reference fields).
+              </p>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.85rem" }}>
+                  <thead>
+                    <tr>
+                      <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "1px solid var(--border)", minWidth: 280 }}>
+                        KPI sub-field
+                      </th>
+                      <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "1px solid var(--border)", minWidth: 260 }}>
+                        Odoo column
+                      </th>
+                      <th style={{ textAlign: "left", padding: "0.5rem", borderBottom: "1px solid var(--border)", minWidth: 220 }}>
+                        List value part
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {subFieldList.map((sf) => {
+                      const selectedCol = mappingBySubKey[sf.key] ?? "";
+                      const listParts = selectedCol ? listColumnPartsByOdooCol[selectedCol] : undefined;
+                      const selectedListIdx = listIndexBySubKey[sf.key] ?? "";
+                      return (
+                        <tr key={sf.key}>
+                          <td style={{ padding: "0.5rem", borderBottom: "1px solid var(--border)", verticalAlign: "top" }}>
+                            <div style={{ fontWeight: 500 }}>{sf.name}</div>
+                            <div style={{ fontSize: "0.75rem", color: "var(--muted)", fontFamily: "monospace" }}>{sf.key}</div>
+                            {isReferenceLike(sf.field_type) && (
+                              <div
+                                style={{
+                                  display: "inline-block",
+                                  marginTop: "0.25rem",
+                                  fontSize: "0.7rem",
+                                  fontWeight: 600,
+                                  color: "var(--primary)",
+                                  padding: "0.1rem 0.35rem",
+                                  borderRadius: 4,
+                                  background: "rgba(var(--primary-rgb, 59, 130, 246), 0.12)",
+                                }}
+                              >
+                                External / linked field
+                              </div>
+                            )}
+                            {renderSubFieldContext(sf)}
+                          </td>
+                          <td style={{ padding: "0.5rem", borderBottom: "1px solid var(--border)", verticalAlign: "top" }}>
+                            <select
+                              value={selectedCol}
+                              onChange={(e) => setOdooColumnForSubField(sf.key, e.target.value)}
+                              style={{ width: "100%", maxWidth: 360 }}
+                            >
+                              <option value="">— Not mapped —</option>
+                              {odooColumns.map((col) => (
+                                <option key={col} value={col}>
+                                  {col}
+                                  {listColumnPartsByOdooCol[col]?.length ? " [list]" : ""}
+                                </option>
+                              ))}
+                            </select>
+                            {renderOdooColumnContext(selectedCol)}
+                          </td>
+                          <td style={{ padding: "0.5rem", borderBottom: "1px solid var(--border)", verticalAlign: "top" }}>
+                            {listParts?.length ? (
+                              <>
+                                <select
+                                  value={selectedListIdx === "" ? "" : String(selectedListIdx)}
+                                  onChange={(e) => {
+                                    const v = e.target.value;
+                                    setListIndexBySubKey((prev) => ({
+                                      ...prev,
+                                      [sf.key]: v === "" ? "" : Number(v),
+                                    }));
+                                  }}
+                                  style={{ width: "100%", maxWidth: 360 }}
+                                >
+                                  <option value="">— Full list value —</option>
+                                  {listParts.map((part) => (
+                                    <option key={part.index} value={String(part.index)}>
+                                      [{part.index}] {part.sample || "(empty)"}
+                                    </option>
+                                  ))}
+                                </select>
+                                <div style={hintBlockStyle}>
+                                  Odoo returned a list for this column (e.g. many2one{" "}
+                                  <code style={{ fontSize: "0.75rem" }}>[id, name]</code>). Choose which index maps to
+                                  this KPI field.
+                                </div>
+                              </>
+                            ) : (
+                              <span style={{ fontSize: "0.8rem", color: "var(--muted)" }}>—</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              {unmappedOdooColumns.length > 0 && (
+                <p style={{ fontSize: "0.8rem", color: "var(--muted)", marginTop: "0.5rem" }}>
+                  Unmapped Odoo columns: {unmappedOdooColumns.join(", ")}
+                </p>
+              )}
+              <button
+                type="button"
+                className="btn btn-primary"
+                style={{ marginTop: "0.75rem" }}
+                disabled={savingMappings}
+                onClick={saveFieldMappings}
+              >
+                {savingMappings ? "Saving…" : "Save field mappings"}
+              </button>
+            </div>
+          )}
+
+          {odooColumns.length > 0 && subFieldList.length === 0 && (
+            <p style={{ marginTop: "1rem", fontSize: "0.85rem", color: "var(--muted)" }}>
+              Add sub-fields to this multi-line field before mapping Odoo columns.
+            </p>
+          )}
+        </>
+      ) : (
+        <p style={{ marginTop: "1rem", fontSize: "0.85rem", color: "var(--muted)" }}>
+          Add a multi-line items field to this KPI to fetch Odoo data and configure field mappings.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduced new database tables for Odoo configurations: `organization_odoo_configs` and `kpi_odoo_configs`.
- Implemented API endpoints for managing Odoo settings at both organization and KPI levels, including retrieval, update, and status checks.
- Enhanced multi-items import capabilities to support Odoo as a data source, including validation and error handling for Odoo configurations.
- Updated frontend components to integrate Odoo import options and display relevant configuration statuses.
- Added necessary schemas for Odoo configuration management in the backend.